### PR TITLE
[DONT MERGE] Adding framework adapater skeleton to torchtalk

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dependencies = [
 dev = [
     "pytest>=7.0.0",
     "pytest-asyncio>=0.21.0",
+    "ruff",
 ]
 
 [project.scripts]

--- a/src/torchtalk/adapters/__init__.py
+++ b/src/torchtalk/adapters/__init__.py
@@ -1,0 +1,42 @@
+"""Framework adapter package."""
+
+from .base import DEFAULT_FRAMEWORK, KNOWN_FRAMEWORKS, FrameworkAdapter, FrameworkId
+
+__all__ = [
+    "DEFAULT_FRAMEWORK",
+    "KNOWN_FRAMEWORKS",
+    "FrameworkAdapter",
+    "FrameworkId",
+    "PyTorchAdapter",
+    "get_adapter",
+    "list_adapters",
+    "register_adapter",
+    "unregister_adapter",
+]
+
+
+def __getattr__(name: str):
+    if name == "PyTorchAdapter":
+        from .pytorch import PyTorchAdapter
+
+        return PyTorchAdapter
+    if name in {
+        "get_adapter",
+        "list_adapters",
+        "register_adapter",
+        "unregister_adapter",
+    }:
+        from .registry import (
+            get_adapter,
+            list_adapters,
+            register_adapter,
+            unregister_adapter,
+        )
+
+        return {
+            "get_adapter": get_adapter,
+            "list_adapters": list_adapters,
+            "register_adapter": register_adapter,
+            "unregister_adapter": unregister_adapter,
+        }[name]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/torchtalk/adapters/base.py
+++ b/src/torchtalk/adapters/base.py
@@ -1,0 +1,31 @@
+"""Adapter interfaces for framework-specific TorchTalk bootstrap."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Protocol
+
+DEFAULT_FRAMEWORK = "pytorch"
+KNOWN_FRAMEWORKS = ("pytorch", "vllm")
+FrameworkId = str
+
+
+class FrameworkAdapter(Protocol):
+    """Minimal contract for framework-aware bootstrap."""
+
+    framework_id: FrameworkId
+    display_name: str
+
+    def resolve_source(self, cli_flag: str | None = None) -> str | None:
+        """Resolve the source root for this framework."""
+
+    def validate_source(self, path: str | Path) -> tuple[bool, str]:
+        """Validate that a source path is usable for this framework."""
+
+    def bootstrap(
+        self,
+        source: str | None = None,
+        *,
+        index_path: str | None = None,
+    ) -> None:
+        """Initialize TorchTalk state from a source tree or cached index."""

--- a/src/torchtalk/adapters/pytorch.py
+++ b/src/torchtalk/adapters/pytorch.py
@@ -1,0 +1,41 @@
+"""PyTorch adapter for legacy TorchTalk bootstrap."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from ..config import resolve_framework_source, validate_framework_path
+
+
+@dataclass(frozen=True)
+class PyTorchAdapter:
+    """Thin adapter that delegates to the existing PyTorch bootstrap."""
+
+    framework_id: str = "pytorch"
+    display_name: str = "PyTorch"
+
+    def resolve_source(self, cli_flag: str | None = None) -> str | None:
+        return resolve_framework_source(self.framework_id, cli_flag)
+
+    def validate_source(self, path: str | Path) -> tuple[bool, str]:
+        return validate_framework_path(self.framework_id, path)
+
+    def bootstrap(
+        self,
+        source: str | None = None,
+        *,
+        index_path: str | None = None,
+    ) -> None:
+        from .. import indexer
+
+        if source:
+            indexer._init_from_source(source, framework=self.framework_id)
+            return
+        if index_path:
+            indexer._load_from_json(
+                index_path,
+                framework=self.framework_id,
+            )
+            return
+        raise ValueError("PyTorchAdapter.bootstrap requires source or index_path")

--- a/src/torchtalk/adapters/registry.py
+++ b/src/torchtalk/adapters/registry.py
@@ -1,0 +1,50 @@
+"""Registry for framework adapters."""
+
+from __future__ import annotations
+
+from .base import DEFAULT_FRAMEWORK, FrameworkAdapter, FrameworkId
+from .pytorch import PyTorchAdapter
+
+_ADAPTERS: dict[FrameworkId, FrameworkAdapter] = {}
+
+
+def register_adapter(
+    adapter: FrameworkAdapter,
+    *,
+    overwrite: bool = False,
+) -> FrameworkAdapter:
+    """Register a framework adapter."""
+
+    framework_id = adapter.framework_id.lower()
+    if framework_id in _ADAPTERS and not overwrite:
+        raise ValueError(f"Adapter already registered for framework '{framework_id}'")
+    _ADAPTERS[framework_id] = adapter
+    return adapter
+
+
+def unregister_adapter(framework_id: FrameworkId) -> FrameworkAdapter | None:
+    """Remove a registered adapter."""
+
+    return _ADAPTERS.pop(framework_id.lower(), None)
+
+
+def get_adapter(framework_id: FrameworkId = DEFAULT_FRAMEWORK) -> FrameworkAdapter:
+    """Get a registered adapter by framework id."""
+
+    normalized = framework_id.lower()
+    try:
+        return _ADAPTERS[normalized]
+    except KeyError as exc:
+        known = ", ".join(sorted(_ADAPTERS))
+        raise KeyError(
+            f"Unknown framework '{framework_id}'. Registered adapters: {known or 'none'}"
+        ) from exc
+
+
+def list_adapters() -> tuple[FrameworkId, ...]:
+    """Return the registered framework ids."""
+
+    return tuple(sorted(_ADAPTERS))
+
+
+register_adapter(PyTorchAdapter())

--- a/src/torchtalk/analysis/binding_detector.py
+++ b/src/torchtalk/analysis/binding_detector.py
@@ -163,8 +163,14 @@ class BindingDetector:
         parser = self.cuda_parser if is_cuda else self.cpp_parser
 
         try:
-            tree = parser.parse(bytes(content, "utf8"))
-            root_node = tree.root_node
+            # tree-sitter-language-pack has shipped parser wrappers that expect
+            # either `str` or UTF-8 `bytes`, depending on version. Support both
+            # so local dev env changes do not break binding detection tests.
+            try:
+                tree = parser.parse(content)
+            except TypeError:
+                tree = parser.parse(bytes(content, "utf8"))
+            root_node = tree.root_node() if callable(tree.root_node) else tree.root_node
         except Exception as e:
             log.warning(f"Parse error for {file_path}: {e}")
             return graph
@@ -195,14 +201,14 @@ class BindingDetector:
     def _find_pybind11_modules(self, node, content: str) -> list[tuple[str, Any]]:
         modules = []
 
-        if node.type == "function_definition":
+        if self._node_kind(node) == "function_definition":
             text = self._get_node_text(node, content)
             match = re.search(r"PYBIND11_MODULE\s*\(\s*(\w+)\s*,", text)
             if match:
                 module_name = match.group(1)
                 modules.append((module_name, node))
 
-        for child in node.children:
+        for child in self._node_children(node):
             modules.extend(self._find_pybind11_modules(child, content))
 
         return modules
@@ -216,8 +222,8 @@ class BindingDetector:
         graph: BindingGraph,
     ):
         body = None
-        for child in module_node.children:
-            if child.type == "compound_statement":
+        for child in self._node_children(module_node):
+            if self._node_kind(child) == "compound_statement":
                 body = child
                 break
 
@@ -225,7 +231,7 @@ class BindingDetector:
             return
 
         body_text = self._get_node_text(body, content)
-        body_start_line = body.start_point[0] + 1
+        body_start_line = self._node_start_line(body)
 
         self._extract_function_bindings(
             body_text, body_start_line, file_path, module_name, graph
@@ -600,7 +606,32 @@ class BindingDetector:
         return None
 
     def _get_node_text(self, node, content: str) -> str:
-        return content[node.start_byte : node.end_byte]
+        start_byte = self._call_or_value(node.start_byte)
+        end_byte = self._call_or_value(node.end_byte)
+        return content[start_byte:end_byte]
+
+    def _node_kind(self, node) -> str:
+        node_type = getattr(node, "type", None)
+        if node_type is not None:
+            return self._call_or_value(node_type)
+        return self._call_or_value(node.kind)
+
+    def _node_children(self, node) -> list[Any]:
+        children = getattr(node, "children", None)
+        if children is not None:
+            return list(self._call_or_value(children))
+        child_count = self._call_or_value(node.child_count)
+        child_fn = node.child
+        return [child_fn(i) for i in range(child_count)]
+
+    def _node_start_line(self, node) -> int:
+        start_point = getattr(node, "start_point", None)
+        if start_point is not None:
+            return self._call_or_value(start_point)[0] + 1
+        return self._call_or_value(node.start_position)[0] + 1
+
+    def _call_or_value(self, value):
+        return value() if callable(value) else value
 
     def detect_bindings_in_directory(self, directory: str) -> BindingGraph:
         """Scan a directory for cross-language bindings."""

--- a/src/torchtalk/cli.py
+++ b/src/torchtalk/cli.py
@@ -13,10 +13,13 @@ import argparse
 import json
 import logging
 import shutil
+import subprocess
 import sys
 from pathlib import Path
 
 log = logging.getLogger(__name__)
+
+_DEFAULT_LINT_PATHS = ["src/torchtalk", "tests"]
 
 
 def cmd_init(args):
@@ -174,6 +177,40 @@ def cmd_status(args):
     lines.append("")
     lines.append("Status: Ready")
     print("\n".join(lines))
+
+
+def cmd_lint(args):
+    """Run Ruff lint checks for the TorchTalk repo."""
+
+    ruff = shutil.which("ruff")
+    if not ruff:
+        log.error(
+            "ruff is not installed. Install with 'pip install -e \".[dev]\"' or "
+            "'pip install ruff'."
+        )
+        return 1
+
+    paths = args.paths or _DEFAULT_LINT_PATHS
+    commands = []
+
+    check_cmd = [ruff, "check"]
+    if args.fix:
+        check_cmd.append("--fix")
+    check_cmd.extend(paths)
+    commands.append(check_cmd)
+
+    if args.format:
+        format_cmd = [ruff, "format"]
+        if not args.fix:
+            format_cmd.append("--check")
+        format_cmd.extend(paths)
+        commands.append(format_cmd)
+
+    for command in commands:
+        result = subprocess.run(command)
+        if result.returncode != 0:
+            return result.returncode
+    return 0
 
 
 def cmd_mcp_serve(args):
@@ -572,6 +609,28 @@ Example:
         "status",
         help="Show configuration and cache status",
     ).set_defaults(func=cmd_status)
+
+    # lint command
+    parser_lint = subparsers.add_parser(
+        "lint",
+        help="Run Ruff lint checks for TorchTalk",
+    )
+    parser_lint.add_argument(
+        "paths",
+        nargs="*",
+        help="Paths to lint (default: src/torchtalk tests)",
+    )
+    parser_lint.add_argument(
+        "--fix",
+        action="store_true",
+        help="Apply Ruff auto-fixes where possible",
+    )
+    parser_lint.add_argument(
+        "--format",
+        action="store_true",
+        help="Also run Ruff format (check-only unless --fix is set)",
+    )
+    parser_lint.set_defaults(func=cmd_lint)
 
     # index command: headless build-and-exit
     parser_index = subparsers.add_parser(

--- a/src/torchtalk/config.py
+++ b/src/torchtalk/config.py
@@ -14,6 +14,8 @@ import os
 import sys
 from pathlib import Path
 
+from .adapters.base import DEFAULT_FRAMEWORK, FrameworkId
+
 if sys.version_info >= (3, 11):
     import tomllib
 else:
@@ -34,6 +36,13 @@ log = logging.getLogger(__name__)
 CONFIG_DIR = user_config_path("torchtalk")
 CONFIG_FILE = CONFIG_DIR / "config.toml"
 CACHE_DIR = user_cache_path("torchtalk")
+
+_FRAMEWORK_CONFIG_KEYS = {
+    "pytorch": "pytorch_source",
+}
+_FRAMEWORK_ENV_VARS = {
+    "pytorch": ("PYTORCH_SOURCE", "PYTORCH_PATH"),
+}
 
 
 def load_config() -> dict:
@@ -73,6 +82,48 @@ def save_config(config: dict) -> Path:
     return CONFIG_FILE
 
 
+def _normalize_framework(framework: FrameworkId | None) -> FrameworkId:
+    return (framework or DEFAULT_FRAMEWORK).lower()
+
+
+def _resolve_source_from_config(
+    cli_flag: str | None,
+    *,
+    env_vars: tuple[str, ...],
+    config_key: str,
+) -> str | None:
+    """Resolve a source path with CLI, env, then config precedence."""
+
+    if cli_flag:
+        return cli_flag
+
+    for env_var in env_vars:
+        env_val = os.environ.get(env_var)
+        if env_val and Path(env_val).exists():
+            return env_val
+
+    config = load_config()
+    config_val = config.get("source", {}).get(config_key)
+    if config_val and Path(config_val).exists():
+        return config_val
+
+    return None
+
+
+def resolve_framework_source(
+    framework: FrameworkId = DEFAULT_FRAMEWORK,
+    cli_flag: str | None = None,
+) -> str | None:
+    """Resolve a source path for the requested framework."""
+
+    normalized = _normalize_framework(framework)
+    config_key = _FRAMEWORK_CONFIG_KEYS.get(normalized)
+    env_vars = _FRAMEWORK_ENV_VARS.get(normalized)
+    if config_key is None or env_vars is None:
+        raise ValueError(f"Unsupported framework: {framework}")
+    return _resolve_source_from_config(cli_flag, env_vars=env_vars, config_key=config_key)
+
+
 def resolve_pytorch_source(cli_flag: str | None = None) -> str | None:
     """Resolve PyTorch source path using 3-level priority.
 
@@ -80,22 +131,8 @@ def resolve_pytorch_source(cli_flag: str | None = None) -> str | None:
     2. PYTORCH_SOURCE env var
     3. config.toml [source] pytorch_source
     """
-    # Level 1: CLI flag
-    if cli_flag:
-        return cli_flag
 
-    # Level 2: Environment variable
-    env_val = os.environ.get("PYTORCH_SOURCE") or os.environ.get("PYTORCH_PATH")
-    if env_val and Path(env_val).exists():
-        return env_val
-
-    # Level 3: Config file
-    config = load_config()
-    config_val = config.get("source", {}).get("pytorch_source")
-    if config_val and Path(config_val).exists():
-        return config_val
-
-    return None
+    return resolve_framework_source("pytorch", cli_flag)
 
 
 def source_hash(source: str | Path) -> str:
@@ -125,11 +162,9 @@ def cache_paths(source: str | Path) -> dict[str, Path]:
     }
 
 
-def validate_pytorch_path(path: str | Path) -> tuple[bool, str]:
-    """Validate that a path looks like a PyTorch source checkout.
+def _validate_pytorch_path(path: str | Path) -> tuple[bool, str]:
+    """Validate that a path looks like a PyTorch source checkout."""
 
-    Returns (is_valid, message).
-    """
     p = Path(path)
     if not p.exists():
         return False, f"Path does not exist: {p}"
@@ -144,3 +179,24 @@ def validate_pytorch_path(path: str | Path) -> tuple[bool, str]:
             f"native_functions.yaml not found in {p} (required for operator indexing)",
         )
     return True, f"Valid PyTorch source: {p}"
+
+
+def validate_framework_path(
+    framework: FrameworkId = DEFAULT_FRAMEWORK,
+    path: str | Path = "",
+) -> tuple[bool, str]:
+    """Validate that a path looks usable for the requested framework."""
+
+    normalized = _normalize_framework(framework)
+    if normalized == "pytorch":
+        return _validate_pytorch_path(path)
+    raise ValueError(f"Unsupported framework: {framework}")
+
+
+def validate_pytorch_path(path: str | Path) -> tuple[bool, str]:
+    """Validate that a path looks like a PyTorch source checkout.
+
+    Returns (is_valid, message).
+    """
+
+    return validate_framework_path("pytorch", path)

--- a/src/torchtalk/indexer.py
+++ b/src/torchtalk/indexer.py
@@ -11,6 +11,8 @@ from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any
 
+from .adapters.base import DEFAULT_FRAMEWORK
+from .adapters.registry import get_adapter
 from .analysis.helpers import levenshtein_distance, truncate
 from .analysis.patterns import (
     CPP_SEARCH_DIRS,
@@ -34,6 +36,8 @@ log = logging.getLogger(__name__)
 class ServerState:
     """Server state container."""
 
+    framework: str = DEFAULT_FRAMEWORK
+    source_root: str | None = None
     bindings: list[dict] = field(default_factory=list)
     cuda_kernels: list[dict] = field(default_factory=list)
     native_functions: dict[str, dict] = field(default_factory=dict)
@@ -75,6 +79,7 @@ class ServerState:
 
 
 _state = ServerState()
+_active_adapter_id: str = DEFAULT_FRAMEWORK
 
 
 def _cache_path(source: str) -> Path:
@@ -393,6 +398,7 @@ def _build_index(source: str) -> dict[str, Any]:
         "native_implementations": implementations,
         "symbol_to_file": symbol_to_file,
         "metadata": {
+            "framework": _state.framework or DEFAULT_FRAMEWORK,
             "source_path": source,
             "source_fingerprint": _source_fingerprint(source),
             "format_version": _BINDINGS_CACHE_FORMAT_VERSION,
@@ -441,13 +447,18 @@ def _build_indexes(state: ServerState):
                 state.ops_by_file.setdefault(fp, set()).add(op_name)
 
 
-def _load_from_json(path: str):
+def _load_from_json(
+    path: str,
+    *,
+    framework: str = DEFAULT_FRAMEWORK,
+):
     """Load bindings from JSON file."""
     global _state
 
     log.info(f"Loading bindings from {path}...")
     with open(path) as f:
         data = json.load(f)
+    metadata = data.get("metadata", {})
 
     _state.bindings = data.get("bindings", [])
     _state.cuda_kernels = data.get("cuda_kernels", [])
@@ -455,6 +466,11 @@ def _load_from_json(path: str):
     _state.derivatives = data.get("derivatives", {})
     _state.native_implementations = data.get("native_implementations", {})
     _state.symbol_to_file = data.get("symbol_to_file", {})
+    _state.framework = metadata.get("framework", framework)
+    source_root = metadata.get("source_path")
+    _state.source_root = str(Path(source_root).resolve()) if source_root else None
+    if _state.framework == "pytorch":
+        _state.pytorch_source = _state.source_root
 
     _build_indexes(_state)
 
@@ -664,7 +680,11 @@ def _init_py_cpp_edges(source: str) -> None:
         log.debug(f"Failed to save py→cpp edges cache: {e}")
 
 
-def _init_from_source(source: str):
+def _init_from_source(
+    source: str,
+    *,
+    framework: str = DEFAULT_FRAMEWORK,
+):
     """Initialize from PyTorch source."""
     global _state
 
@@ -672,12 +692,18 @@ def _init_from_source(source: str):
     if not src.exists():
         raise FileNotFoundError(f"Source not found: {source}")
 
-    cache = _cache_path(str(src))
-    if _cache_valid(cache, str(src)):
+    resolved_source = str(src)
+    _state.framework = framework
+    _state.source_root = resolved_source
+    if framework == "pytorch":
+        _state.pytorch_source = resolved_source
+
+    cache = _cache_path(resolved_source)
+    if _cache_valid(cache, resolved_source):
         log.info(f"Using cached index from {cache}")
-        _load_from_json(str(cache))
+        _load_from_json(str(cache), framework=framework)
     else:
-        data = _build_index(str(src))
+        data = _build_index(resolved_source)
         _state.bindings = data.get("bindings", [])
         _state.cuda_kernels = data.get("cuda_kernels", [])
         _state.native_functions = data.get("native_functions", {})
@@ -686,13 +712,45 @@ def _init_from_source(source: str):
         _state.symbol_to_file = data.get("symbol_to_file", {})
         _build_indexes(_state)
 
-    _state.pytorch_source = str(src)
-    _init_decomp_aliases(str(src))
+    _state.pytorch_source = resolved_source
+    _state.source_root = resolved_source
+    _init_decomp_aliases(resolved_source)
     _init_backward_bridge()
-    _init_dispatch_stubs(str(src))
-    _init_cpp_call_graph(str(src))
-    _init_python_modules(str(src))
-    _init_test_infrastructure(str(src))
+    _init_dispatch_stubs(resolved_source)
+    _init_cpp_call_graph(resolved_source)
+    _init_python_modules(resolved_source)
+    _init_test_infrastructure(resolved_source)
+
+
+def init_via_adapter(
+    framework: str = DEFAULT_FRAMEWORK,
+    *,
+    cli_source: str | None = None,
+    source: str | None = None,
+    index_path: str | None = None,
+) -> str | None:
+    """Initialize state via the registered framework adapter."""
+
+    global _active_adapter_id
+
+    adapter = get_adapter(framework)
+    resolved_source = source or adapter.resolve_source(cli_source)
+    _state.framework = adapter.framework_id
+
+    if resolved_source:
+        adapter.bootstrap(resolved_source)
+        _state.source_root = str(Path(resolved_source).resolve())
+    elif index_path:
+        adapter.bootstrap(index_path=index_path)
+        if _state.framework == "pytorch" and _state.source_root is None:
+            _state.source_root = _state.pytorch_source
+    else:
+        _state.source_root = None
+        if adapter.framework_id == "pytorch":
+            _state.pytorch_source = None
+
+    _active_adapter_id = adapter.framework_id
+    return resolved_source
 
 
 def _init_decomp_aliases(source: str):
@@ -1471,7 +1529,7 @@ def build_index(source: str, wait_for_cpp: bool = True) -> dict:
     when wait_for_cpp is True; otherwise returns while it builds in the
     background.
     """
-    _init_from_source(source)
+    init_via_adapter(source=source)
 
     if wait_for_cpp and _state.cpp_thread is not None and _state.cpp_thread.is_alive():
         log.info("Waiting for C++ call graph build to finish...")

--- a/src/torchtalk/server.py
+++ b/src/torchtalk/server.py
@@ -8,11 +8,10 @@ from typing import Literal
 
 from mcp.server.fastmcp import FastMCP
 
+from .adapters import DEFAULT_FRAMEWORK, get_adapter
 from .formatting import create_formatter
 from .indexer import (
-    _auto_detect_pytorch,
-    _init_from_source,
-    _load_from_json,
+    init_via_adapter,
     _state,
 )
 from .tools.affected import _do_affected
@@ -36,6 +35,17 @@ async def get_status() -> str:
     """Get TorchTalk status and available tools."""
     md = create_formatter()
     md.h2("TorchTalk Status")
+
+    try:
+        framework_name = get_adapter(_state.framework).display_name
+    except KeyError:
+        framework_name = _state.framework
+    md.bold("Framework", framework_name)
+    if _state.source_root:
+        md.code("Source Root", _state.source_root)
+    else:
+        md.bold("Source Root", "Not configured")
+    md.blank()
 
     if _state.pytorch_source:
         md.code("PyTorch Source", _state.pytorch_source)
@@ -297,23 +307,23 @@ def run_server(
     pytorch_source: str | None = None,
     index_path: str | None = None,
     transport: str = "stdio",
+    framework: str = DEFAULT_FRAMEWORK,
 ):
     """Start MCP server. Heavy init runs in background so the MCP client's
     initialize handshake completes immediately; tools return a 'not loaded'
     error via `_ensure_loaded` until the data is ready."""
     import threading
 
-    source = pytorch_source or _auto_detect_pytorch()
-
     def _bg_init():
         try:
-            if source:
-                _init_from_source(source)
-            elif index_path:
-                _load_from_json(index_path)
-            else:
+            source = init_via_adapter(
+                framework=framework,
+                cli_source=pytorch_source,
+                index_path=index_path,
+            )
+            if not source and not index_path:
                 log.warning(
-                    "No PyTorch source specified. "
+                    f"No {framework} source specified. "
                     "Tools will return errors until data is loaded."
                 )
         except Exception:

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -1,0 +1,71 @@
+"""Tests for framework adapter registration and bootstrap dispatch."""
+
+from __future__ import annotations
+
+from torchtalk import indexer
+from torchtalk.adapters import (
+    get_adapter,
+    register_adapter,
+    unregister_adapter,
+)
+
+
+class FakeAdapter:
+    framework_id = "fake"
+    display_name = "Fake Framework"
+
+    def __init__(self, calls: list[tuple]):
+        self.calls = calls
+
+    def resolve_source(self, cli_flag: str | None = None) -> str | None:
+        self.calls.append(("resolve_source", cli_flag))
+        return cli_flag or "/tmp/fake-source"
+
+    def validate_source(self, path):
+        return True, f"Valid fake source: {path}"
+
+    def bootstrap(
+        self,
+        source: str | None = None,
+        *,
+        index_path: str | None = None,
+    ) -> None:
+        self.calls.append(("bootstrap", source, index_path))
+
+
+class TestAdapterRegistry:
+    def test_default_adapter_is_pytorch(self):
+        adapter = get_adapter()
+        assert adapter.framework_id == "pytorch"
+        assert adapter.display_name == "PyTorch"
+
+    def test_can_register_and_unregister_fake_adapter(self):
+        calls: list[tuple] = []
+        adapter = FakeAdapter(calls)
+        register_adapter(adapter)
+        try:
+            assert get_adapter("fake") is adapter
+        finally:
+            unregister_adapter("fake")
+
+
+class TestAdapterBootstrap:
+    def test_init_via_adapter_uses_registered_adapter(self):
+        prior_framework = indexer._state.framework
+        prior_source_root = indexer._state.source_root
+        prior_pytorch_source = indexer._state.pytorch_source
+
+        calls: list[tuple] = []
+        adapter = FakeAdapter(calls)
+        register_adapter(adapter)
+        try:
+            resolved = indexer.init_via_adapter(framework="fake", source="/tmp/fake-root")
+            assert resolved == "/tmp/fake-root"
+            assert calls == [("bootstrap", "/tmp/fake-root", None)]
+            assert indexer._state.framework == "fake"
+            assert indexer._state.source_root == "/tmp/fake-root"
+        finally:
+            unregister_adapter("fake")
+            indexer._state.framework = prior_framework
+            indexer._state.source_root = prior_source_root
+            indexer._state.pytorch_source = prior_pytorch_source

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 import json
+from argparse import Namespace
+from types import SimpleNamespace
 
 from torchtalk.cli import (
     _format_coverage,
     _read_cache_stats,
     _read_coverage_from_cache,
+    cmd_lint,
 )
 
 
@@ -143,3 +146,47 @@ class TestReadCacheStats:
         path = tmp_path / "cg.json"
         path.write_text("not json")
         assert _read_cache_stats(path) is None
+
+
+class TestLintCommand:
+    def test_returns_one_when_ruff_missing(self, monkeypatch):
+        import torchtalk.cli as cli_mod
+
+        monkeypatch.setattr(cli_mod.shutil, "which", lambda _cmd: None)
+        args = Namespace(paths=[], fix=False, format=False)
+        assert cmd_lint(args) == 1
+
+    def test_uses_default_paths(self, monkeypatch):
+        import torchtalk.cli as cli_mod
+
+        seen: list[list[str]] = []
+        monkeypatch.setattr(cli_mod.shutil, "which", lambda _cmd: "/usr/bin/ruff")
+
+        def fake_run(command):
+            seen.append(command)
+            return SimpleNamespace(returncode=0)
+
+        monkeypatch.setattr(cli_mod.subprocess, "run", fake_run)
+        args = Namespace(paths=[], fix=False, format=False)
+
+        assert cmd_lint(args) == 0
+        assert seen == [["/usr/bin/ruff", "check", "src/torchtalk", "tests"]]
+
+    def test_fix_and_format_issue_expected_commands(self, monkeypatch):
+        import torchtalk.cli as cli_mod
+
+        seen: list[list[str]] = []
+        monkeypatch.setattr(cli_mod.shutil, "which", lambda _cmd: "/usr/bin/ruff")
+
+        def fake_run(command):
+            seen.append(command)
+            return SimpleNamespace(returncode=0)
+
+        monkeypatch.setattr(cli_mod.subprocess, "run", fake_run)
+        args = Namespace(paths=["src/torchtalk"], fix=True, format=True)
+
+        assert cmd_lint(args) == 0
+        assert seen == [
+            ["/usr/bin/ruff", "check", "--fix", "src/torchtalk"],
+            ["/usr/bin/ruff", "format", "src/torchtalk"],
+        ]

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -36,6 +36,8 @@ from torchtalk.indexer import (
 class TestServerState:
     def test_default_empty(self):
         state = ServerState()
+        assert state.framework == "pytorch"
+        assert state.source_root is None
         assert state.bindings == []
         assert state.native_functions == {}
         assert state.pytorch_source is None
@@ -300,6 +302,64 @@ class TestPyCppEdgesCache:
         monkeypatch.setattr(indexer, "_source_fingerprint", lambda _: "fp_v2")
         indexer._state.py_to_cpp_edges = {}
         assert _load_py_cpp_edges_cache(cache, "/fake/source") is False
+
+
+class TestLoadFromJsonState:
+    def test_load_from_json_populates_framework_and_source_root(self, tmp_path):
+        prior_framework = indexer._state.framework
+        prior_source_root = indexer._state.source_root
+        prior_pytorch_source = indexer._state.pytorch_source
+        prior_bindings = indexer._state.bindings
+        prior_cuda_kernels = indexer._state.cuda_kernels
+        prior_native_functions = indexer._state.native_functions
+        prior_derivatives = indexer._state.derivatives
+        prior_native_impls = indexer._state.native_implementations
+        prior_symbol_to_file = indexer._state.symbol_to_file
+        prior_by_python_name = indexer._state.by_python_name
+        prior_by_cpp_name = indexer._state.by_cpp_name
+        prior_by_dispatch_key = indexer._state.by_dispatch_key
+        prior_bindings_by_file = indexer._state.bindings_by_file
+        prior_ops_by_file = indexer._state.ops_by_file
+        prior_dispatch_to_op = indexer._state.dispatch_to_op
+        try:
+            source_root = tmp_path / "pytorch-src"
+            source_root.mkdir()
+            payload = {
+                "bindings": [],
+                "cuda_kernels": [],
+                "native_functions": {},
+                "derivatives": {},
+                "native_implementations": {},
+                "symbol_to_file": {},
+                "metadata": {
+                    "framework": "pytorch",
+                    "source_path": str(source_root),
+                },
+            }
+            path = tmp_path / "bindings.json"
+            path.write_text(json.dumps(payload))
+
+            indexer._load_from_json(str(path))
+
+            assert indexer._state.framework == "pytorch"
+            assert indexer._state.source_root == str(source_root.resolve())
+            assert indexer._state.pytorch_source == str(source_root.resolve())
+        finally:
+            indexer._state.framework = prior_framework
+            indexer._state.source_root = prior_source_root
+            indexer._state.pytorch_source = prior_pytorch_source
+            indexer._state.bindings = prior_bindings
+            indexer._state.cuda_kernels = prior_cuda_kernels
+            indexer._state.native_functions = prior_native_functions
+            indexer._state.derivatives = prior_derivatives
+            indexer._state.native_implementations = prior_native_impls
+            indexer._state.symbol_to_file = prior_symbol_to_file
+            indexer._state.by_python_name = prior_by_python_name
+            indexer._state.by_cpp_name = prior_by_cpp_name
+            indexer._state.by_dispatch_key = prior_by_dispatch_key
+            indexer._state.bindings_by_file = prior_bindings_by_file
+            indexer._state.ops_by_file = prior_ops_by_file
+            indexer._state.dispatch_to_op = prior_dispatch_to_op
 
     def test_load_rejects_old_version(self, tmp_path, monkeypatch):
         monkeypatch.setattr(indexer, "_source_fingerprint", lambda _: "fp")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,28 @@
+"""Tests for TorchTalk server status output."""
+
+from __future__ import annotations
+
+from torchtalk import indexer
+from torchtalk.server import get_status
+
+
+class TestStatus:
+    async def test_get_status_includes_framework_and_source_root(self):
+        prior_framework = indexer._state.framework
+        prior_source_root = indexer._state.source_root
+        prior_pytorch_source = indexer._state.pytorch_source
+
+        try:
+            indexer._state.framework = "pytorch"
+            indexer._state.source_root = "/tmp/pytorch-src"
+            indexer._state.pytorch_source = "/tmp/pytorch-src"
+
+            status = await get_status()
+
+            assert "Framework" in status
+            assert "PyTorch" in status
+            assert "/tmp/pytorch-src" in status
+        finally:
+            indexer._state.framework = prior_framework
+            indexer._state.source_root = prior_source_root
+            indexer._state.pytorch_source = prior_pytorch_source


### PR DESCRIPTION
Fixes #7 

minimal adapter layer in torchtalk so startup routes through `PyTorchAdapter` and records the active framework root without changing current PyTorch behavior