### PR TITLE
Improve index accuracy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,8 +30,8 @@ classifiers = [
     "Topic :: Software Development :: Code Generators",
 ]
 dependencies = [
-    "tree-sitter>=0.25",
-    "tree-sitter-language-pack>=1.0",
+    "tree-sitter>=0.26",
+    "tree-sitter-language-pack>=1.12",
     "pathspec>=0.12",
     "pyyaml>=6.0",
     "libclang>=16.0.0",

--- a/src/torchtalk/analysis/binding_detector.py
+++ b/src/torchtalk/analysis/binding_detector.py
@@ -48,7 +48,7 @@ class Binding:
             "cpp_name": self.cpp_name,
             "type": self.binding_type,
             "file_path": self.file_path,
-            "line": self.line_number,
+            "line_number": self.line_number,
             "dispatch_key": self.dispatch_key,
             "namespace": self.namespace,
             "cuda_kernel": self.cuda_kernel,
@@ -81,6 +81,18 @@ class BindingGraph:
     def add_cuda_kernel(self, kernel: CUDAKernel):
         self.cuda_kernels.append(kernel)
 
+
+_CPP_CONTROL_KEYWORDS = {
+    "if",
+    "for",
+    "while",
+    "switch",
+    "do",
+    "else",
+    "return",
+    "catch",
+    "sizeof",
+}
 
 _IMPL_WRAPPERS = ("TORCH_FN_BOXED", "TORCH_FN")
 _NO_IMPL_MARKERS = ("makeFallthrough", "makeNamedNotSupported")
@@ -190,7 +202,12 @@ class BindingDetector:
                 module_node, content, file_path, module_name, graph
             )
 
-        self._extract_standalone_pybind_patterns(content, file_path, graph)
+        # Regions already covered by a PYBIND11_MODULE body are skipped in the
+        # standalone pass — running both fabricates duplicate rows.
+        module_ranges = [(n.start_byte(), n.end_byte()) for _, n in modules]
+        self._extract_standalone_pybind_patterns(
+            content, file_path, graph, module_ranges
+        )
 
     def _find_pybind11_modules(self, node, content: str) -> list[tuple[str, Any]]:
         modules = []
@@ -238,12 +255,18 @@ class BindingDetector:
         )
 
     def _extract_standalone_pybind_patterns(
-        self, content: str, file_path: str, graph: BindingGraph
+        self,
+        content: str,
+        file_path: str,
+        graph: BindingGraph,
+        skip_ranges: list[tuple[int, int]] | None = None,
     ):
         # py::class_<CppClass>(m, "PyClass") or py::class_<CppClass>(parent, "PyClass")
         class_pattern = r'py::class_<([^>]+)>\s*\(\s*\w+\s*,\s*"([^"]+)"'
 
         for match in re.finditer(class_pattern, content):
+            if any(s <= match.start() < e for s, e in skip_ranges or []):
+                continue
             cpp_class = match.group(1).split(",")[0].strip()
             python_name = match.group(2)
             line_number = content[: match.start()].count("\n") + 1
@@ -257,15 +280,20 @@ class BindingDetector:
             )
             graph.add_binding(binding)
 
-            # Find chained .def() methods for this class
-            # Look for .def("name", ...) patterns after the class definition
+            # The .def() chain ends at the statement's semicolon (or the next
+            # py::class_, whichever comes first) — scanning to EOF fabricates
+            # methods belonging to later statements.
             class_end = match.end()
-            # Find the semicolon or next py::class_ to bound the search
             next_class = content.find("py::class_", class_end)
-            if next_class == -1:
-                next_class = len(content)
+            semicolon = content.find(";", class_end)
+            if semicolon == -1:
+                class_extent = len(content) if next_class == -1 else next_class
+            elif next_class == -1:
+                class_extent = semicolon
+            else:
+                class_extent = min(semicolon, next_class)
 
-            class_body = content[class_end:next_class]
+            class_body = content[class_end:class_extent]
 
             # .def("method", &Class::method) or .def("method", [...])
             method_pattern = r'\.def(?:_static|_readwrite|_readonly)?\s*\(\s*"([^"]+)"'
@@ -407,7 +435,13 @@ class BindingDetector:
                 block_content = content[block_start:block_end]
 
                 self._extract_torch_ops(
-                    block_content, line_number, file_path, namespace, None, graph
+                    block_content,
+                    line_number,
+                    file_path,
+                    namespace,
+                    None,
+                    graph,
+                    module_var=match.group(2),
                 )
 
         # TORCH_LIBRARY_IMPL(namespace, dispatch_key, m) { ... }
@@ -432,6 +466,7 @@ class BindingDetector:
                     namespace,
                     dispatch_key,
                     graph,
+                    module_var=match.group(3),
                 )
 
     def _extract_torch_ops(
@@ -442,12 +477,15 @@ class BindingDetector:
         namespace: str,
         dispatch_key: str | None,
         graph: BindingGraph,
+        module_var: str = "m",
     ):
-        # m.def("op_name(Tensor self) -> Tensor", ...)
-        # Also handles: m.def(TORCH_SELECTIVE_SCHEMA("aten::op_name(...)"))
+        # <m>.def("op_name(Tensor self) -> Tensor", ...) where <m> is the
+        # module variable named in the registration macro (vLLM uses `ops`).
+        # Also handles: <m>.def(TORCH_SELECTIVE_SCHEMA("aten::op_name(...)"))
+        mv = re.escape(module_var)
         def_patterns = [
-            r'm\.def\s*\(\s*"([^"]+)"',  # Direct string
-            r'm\.def\s*\(\s*TORCH_SELECTIVE_SCHEMA\s*\(\s*"([^"]+)"',  # Via macro
+            rf'{mv}\.def\s*\(\s*"([^"]+)"',  # Direct string
+            rf'{mv}\.def\s*\(\s*TORCH_SELECTIVE_SCHEMA\s*\(\s*"([^"]+)"',  # Via macro
         ]
 
         for def_pattern in def_patterns:
@@ -475,7 +513,7 @@ class BindingDetector:
         # m.impl("op_name", function_ptr) — function_ptr may be wrapped in
         # TORCH_FN(...), TORCH_FN_BOXED(...), prefixed with `&`, or namespaced
         # (`at::native::foo`). Capture the full target then strip wrappers.
-        impl_pattern = r'm\.impl\s*\(\s*"([^"]+)"\s*,\s*([^,;]+?)\s*(?:[,)]|;)'
+        impl_pattern = rf'{mv}\.impl\s*\(\s*"([^"]+)"\s*,\s*([^,;]+?)\s*(?:[,)]|;)'
         for match in re.finditer(impl_pattern, block_content):
             op_name = match.group(1)
             # Strip overload suffix (`abs.out` → `abs`) so cpp_name is searchable
@@ -595,10 +633,12 @@ class BindingDetector:
             r"(?:static\s+)?(?:inline\s+)?(?:\w+::)*(\w+)\s*\([^)]*\)\s*(?:const\s*)?\{"
         )
 
-        matches = list(re.finditer(func_pattern, search_region))
-        if matches:
-            # Return the last (most recent) match
-            return matches[-1].group(1)
+        # Most recent non-keyword match: `if (...) {` / `for (...) {` blocks
+        # match the pattern but are control flow, not enclosing functions.
+        for match in reversed(list(re.finditer(func_pattern, search_region))):
+            name = match.group(1)
+            if name not in _CPP_CONTROL_KEYWORDS:
+                return name
         return None
 
     def _get_node_text(self, node, content: str) -> str:

--- a/src/torchtalk/analysis/binding_detector.py
+++ b/src/torchtalk/analysis/binding_detector.py
@@ -175,8 +175,8 @@ class BindingDetector:
         parser = self.cuda_parser if is_cuda else self.cpp_parser
 
         try:
-            tree = parser.parse(content)
-            root_node = tree.root_node()
+            tree = parser.parse(content.encode("utf-8", errors="replace"))
+            root_node = tree.root_node
         except Exception as e:
             log.warning(f"Parse error for {file_path}: {e}")
             return graph
@@ -204,7 +204,7 @@ class BindingDetector:
 
         # Regions already covered by a PYBIND11_MODULE body are skipped in the
         # standalone pass — running both fabricates duplicate rows.
-        module_ranges = [(n.start_byte(), n.end_byte()) for _, n in modules]
+        module_ranges = [(n.start_byte, n.end_byte) for _, n in modules]
         self._extract_standalone_pybind_patterns(
             content, file_path, graph, module_ranges
         )
@@ -212,15 +212,14 @@ class BindingDetector:
     def _find_pybind11_modules(self, node, content: str) -> list[tuple[str, Any]]:
         modules = []
 
-        if node.kind() == "function_definition":
+        if node.type == "function_definition":
             text = self._get_node_text(node, content)
             match = re.search(r"PYBIND11_MODULE\s*\(\s*(\w+)\s*,", text)
             if match:
                 module_name = match.group(1)
                 modules.append((module_name, node))
 
-        for i in range(node.child_count()):
-            child = node.child(i)
+        for child in node.children:
             modules.extend(self._find_pybind11_modules(child, content))
 
         return modules
@@ -234,9 +233,8 @@ class BindingDetector:
         graph: BindingGraph,
     ):
         body = None
-        for i in range(module_node.child_count()):
-            child = module_node.child(i)
-            if child.kind() == "compound_statement":
+        for child in module_node.children:
+            if child.type == "compound_statement":
                 body = child
                 break
 
@@ -244,7 +242,7 @@ class BindingDetector:
             return
 
         body_text = self._get_node_text(body, content)
-        body_start_line = body.start_position().row + 1
+        body_start_line = body.start_point.row + 1
 
         self._extract_function_bindings(
             body_text, body_start_line, file_path, module_name, graph
@@ -642,7 +640,7 @@ class BindingDetector:
         return None
 
     def _get_node_text(self, node, content: str) -> str:
-        return content[node.start_byte() : node.end_byte()]
+        return (node.text or b"").decode("utf-8", errors="replace")
 
     def detect_bindings_in_directory(self, directory: str) -> BindingGraph:
         """Scan a directory for cross-language bindings."""

--- a/src/torchtalk/analysis/cpp_call_graph.py
+++ b/src/torchtalk/analysis/cpp_call_graph.py
@@ -139,9 +139,14 @@ def _translate_args(
     file_path: str, compile_args: list[str], cuda_env: dict | None
 ) -> list[str]:
     """Pick the libclang arg set for a TU based on extension and CUDA availability."""
-    if file_path.endswith(".cu") and cuda_env:
-        return _cu_args(compile_args, cuda_env)
-    return [a for a in compile_args if a.startswith(("-I", "-D", "-std"))]
+    keep = [a for a in compile_args if a.startswith(("-I", "-D", "-std"))]
+    if file_path.endswith(".cu"):
+        if cuda_env:
+            return _cu_args(compile_args, cuda_env)
+        # No CUDA toolchain: best-effort host-side parse as C++ so clang
+        # recovers past device-only constructs instead of dropping the TU.
+        return ["-x", "c++", *keep]
+    return keep
 
 
 def _synthesize_missing_cu_entries(
@@ -334,7 +339,7 @@ class CppCallGraphExtractor:
         self.include_dirs = _collect_include_dirs(compile_db, str(source))
 
         cuda_env = _discover_cuda_env()
-        supported_exts = (".cpp", ".cu") if cuda_env else (".cpp",)
+        supported_exts = (".cpp", ".cc", ".cxx", ".cu")
 
         # Filter to relevant files using configurable patterns
         entries = []
@@ -578,6 +583,19 @@ class CppCallGraphExtractor:
             else:
                 results = [_parse_single_file(e) for e in translated]
 
+            # Records are keyed by DEFINING file, so header-defined (inline/
+            # template) functions live under the header's record — which the
+            # TU-path eviction above never touches. Evict every record this
+            # parse re-observes, or stale edges union back in on merge.
+            observed_owners: set[str] = set()
+            for result in results:
+                if result["success"]:
+                    for loc in result.get("function_locations", {}).values():
+                        if loc:
+                            observed_owners.add(loc[0])
+            for owner in observed_owners:
+                self.file_records.pop(owner, None)
+
             for result in results:
                 rel = (
                     _rel_to_root(result.get("file", ""), source_root)
@@ -629,10 +647,15 @@ class CppCallGraphExtractor:
         return result
 
     def coverage_summary(self) -> dict[str, int]:
-        """Count TUs per status bucket from tu_status."""
+        """Count TUs per status bucket, plus unindexed .cu/.cc composition."""
         summary: dict[str, int] = defaultdict(int)
-        for status in self.tu_status.values():
+        for tu, status in self.tu_status.items():
             summary[status] += 1
+            if status in ("parse_failed", "unsupported_language"):
+                if tu.endswith(".cu"):
+                    summary["cu_unindexed"] += 1
+                elif tu.endswith((".cc", ".cxx")):
+                    summary["cc_unindexed"] += 1
         return dict(summary)
 
     def load_from_path(self, cache_path: Path) -> bool:
@@ -704,6 +727,10 @@ class CppCallGraphExtractor:
         """Get functions that call this function (inbound)."""
         return self._get_relations(function_name, "callers", fuzzy)
 
+    def match_functions(self, name: str, fuzzy: bool = True) -> list[str]:
+        """Resolve a query to indexed symbols, ranked (exact, then fuzzy)."""
+        return self._find_matching_functions(name, fuzzy)
+
     def _find_matching_functions(self, name: str, fuzzy: bool) -> list[str]:
         all_funcs = (
             set(self.callees.keys())
@@ -721,7 +748,7 @@ class CppCallGraphExtractor:
         # 2. Namespace suffix match (at::native::gemm matches "gemm")
         matches = [f for f in all_funcs if f.endswith("::" + name) or f == name]
         if matches:
-            return matches
+            return sorted(matches, key=lambda f: (len(f), f))
 
         # 3. Case-insensitive substring match
         name_lower = name.lower()
@@ -743,7 +770,9 @@ class CppCallGraphExtractor:
                 base = f.split("::")[-1] if "::" in f else f
                 if abs(len(base) - len(name)) <= 3:
                     dist = levenshtein_distance(name_lower, base.lower())
-                    if dist <= max(2, len(name) // 3):
+                    # Absolute cap: len//3 alone allows 12 edits on long
+                    # kernel names, cross-matching unrelated ops.
+                    if dist <= min(3, max(2, len(name) // 3)):
                         levenshtein_matches.append((dist, f))
             levenshtein_matches.sort(key=lambda x: x[0])
             levenshtein_matches = [f for _, f in levenshtein_matches[:10]]
@@ -757,25 +786,33 @@ class CppCallGraphExtractor:
                     seen.add(m)
                     result.append(m)
 
-        # Sort by length (prefer shorter/more specific matches)
-        result.sort(key=len)
+        # Shortest first, lexicographic tiebreak — deterministic across runs
+        result.sort(key=lambda f: (len(f), f))
         return result[:20]
 
-    def save_cache(self, cache_key: str) -> Path:
+    def save_cache(self, cache_key: str, fingerprint: str | None = None) -> Path:
         cache_path = self.cache_dir / f"{cache_key}.json"
         data = self.get_call_graph_data()
+        if fingerprint:
+            data["source_fingerprint"] = fingerprint
         with open(cache_path, "w") as f:
             json.dump(data, f)
         log.info(f"Saved call graph cache to {cache_path}")
         return cache_path
 
-    def load_cache(self, cache_key: str) -> bool:
+    def load_cache(self, cache_key: str, expect_fingerprint: str | None = None) -> bool:
         cache_path = self.cache_dir / f"{cache_key}.json"
         if not cache_path.exists():
             return False
         try:
             with open(cache_path) as f:
                 data = json.load(f)
+            if (
+                expect_fingerprint
+                and data.get("source_fingerprint") != expect_fingerprint
+            ):
+                log.info("Call graph cache stale (source changed); rebuilding")
+                return False
             self._apply_loaded_data(data)
             log.info(f"Loaded call graph cache from {cache_path}")
             return True

--- a/src/torchtalk/analysis/cpp_call_graph.py
+++ b/src/torchtalk/analysis/cpp_call_graph.py
@@ -9,7 +9,7 @@ from multiprocessing import Pool, cpu_count
 from pathlib import Path
 from typing import Any
 
-from .helpers import levenshtein_distance
+from .helpers import fuzzy_distance_limit, levenshtein_distance
 from .patterns import CPP_SEARCH_DIRS, should_exclude, should_include_dir
 
 log = logging.getLogger(__name__)
@@ -770,9 +770,7 @@ class CppCallGraphExtractor:
                 base = f.split("::")[-1] if "::" in f else f
                 if abs(len(base) - len(name)) <= 3:
                     dist = levenshtein_distance(name_lower, base.lower())
-                    # Absolute cap: len//3 alone allows 12 edits on long
-                    # kernel names, cross-matching unrelated ops.
-                    if dist <= min(3, max(2, len(name) // 3)):
+                    if dist <= fuzzy_distance_limit(name):
                         levenshtein_matches.append((dist, f))
             levenshtein_matches.sort(key=lambda x: x[0])
             levenshtein_matches = [f for _, f in levenshtein_matches[:10]]

--- a/src/torchtalk/analysis/helpers.py
+++ b/src/torchtalk/analysis/helpers.py
@@ -3,6 +3,12 @@
 from typing import Any
 
 
+def fuzzy_distance_limit(name: str) -> int:
+    """Max edit distance for a fuzzy match; len//3 alone allows 12 edits on
+    long kernel names, cross-matching unrelated ops."""
+    return min(3, max(2, len(name) // 3))
+
+
 def levenshtein_distance(s1: str, s2: str) -> int:
     """Compute Levenshtein edit distance between two strings."""
     if len(s1) < len(s2):

--- a/src/torchtalk/analysis/helpers.py
+++ b/src/torchtalk/analysis/helpers.py
@@ -75,3 +75,23 @@ def dedupe_by_key(items: list[dict], key: str) -> list[dict]:
             seen.add(val)
             result.append(item)
     return result
+
+
+def word_match(query_lower: str, name_lower: str) -> bool:
+    """Match on word boundaries to avoid 'add' matching 'padding'.
+
+    Every occurrence is tried: `test_padding_add` must match "add" even
+    though its first occurrence (inside "padding") fails the boundary check.
+    """
+    idx = name_lower.find(query_lower)
+    while idx != -1:
+        before = name_lower[idx - 1] if idx > 0 else "_"
+        after = (
+            name_lower[idx + len(query_lower)]
+            if idx + len(query_lower) < len(name_lower)
+            else "_"
+        )
+        if not before.isalpha() and not after.isalpha():
+            return True
+        idx = name_lower.find(query_lower, idx + 1)
+    return False

--- a/src/torchtalk/cli.py
+++ b/src/torchtalk/cli.py
@@ -179,11 +179,8 @@ def cmd_status(args):
 def cmd_mcp_serve(args):
     """Start MCP server for Claude Code integration."""
     from torchtalk.formatting import set_formatter_mode
-    from torchtalk.harness import set_active_harness
     from torchtalk.server import run_server
 
-    if args.harness:
-        set_active_harness(args.harness)
     set_formatter_mode(args.format)
     run_server(
         pytorch_source=args.pytorch_source,
@@ -196,11 +193,8 @@ def cmd_mcp_serve(args):
 def cmd_index_build(args):
     """Build or refresh the index for a PyTorch source and exit."""
     from torchtalk.config import resolve_pytorch_source
-    from torchtalk.harness import set_active_harness
     from torchtalk.indexer import build_index
 
-    if args.harness:
-        set_active_harness(args.harness)
     source = args.pytorch_source or resolve_pytorch_source()
     if not source:
         log.error("No PyTorch source configured. Run 'torchtalk init' first.")
@@ -598,10 +592,6 @@ Example:
         action="store_true",
         help="Return immediately instead of waiting for the C++ call graph",
     )
-    p_build.add_argument(
-        "--harness",
-        help="Harness to index with (default: pytorch)",
-    )
     p_build.set_defaults(func=cmd_index_build)
 
     p_update = index_sub.add_parser(
@@ -652,10 +642,6 @@ First run builds the index (a few minutes); subsequent runs use cache.
         default="stdio",
         choices=["stdio", "streamable-http"],
         help="MCP transport type (default: stdio for Claude Code)",
-    )
-    parser_mcp.add_argument(
-        "--harness",
-        help="Harness to index with (default: pytorch)",
     )
     parser_mcp.add_argument(
         "--format",

--- a/src/torchtalk/cli.py
+++ b/src/torchtalk/cli.py
@@ -178,8 +178,13 @@ def cmd_status(args):
 
 def cmd_mcp_serve(args):
     """Start MCP server for Claude Code integration."""
+    from torchtalk.formatting import set_formatter_mode
+    from torchtalk.harness import set_active_harness
     from torchtalk.server import run_server
 
+    if args.harness:
+        set_active_harness(args.harness)
+    set_formatter_mode(args.format)
     run_server(
         pytorch_source=args.pytorch_source,
         index_path=args.index,
@@ -191,8 +196,11 @@ def cmd_mcp_serve(args):
 def cmd_index_build(args):
     """Build or refresh the index for a PyTorch source and exit."""
     from torchtalk.config import resolve_pytorch_source
+    from torchtalk.harness import set_active_harness
     from torchtalk.indexer import build_index
 
+    if args.harness:
+        set_active_harness(args.harness)
     source = args.pytorch_source or resolve_pytorch_source()
     if not source:
         log.error("No PyTorch source configured. Run 'torchtalk init' first.")
@@ -590,6 +598,10 @@ Example:
         action="store_true",
         help="Return immediately instead of waiting for the C++ call graph",
     )
+    p_build.add_argument(
+        "--harness",
+        help="Harness to index with (default: pytorch)",
+    )
     p_build.set_defaults(func=cmd_index_build)
 
     p_update = index_sub.add_parser(
@@ -640,6 +652,16 @@ First run builds the index (a few minutes); subsequent runs use cache.
         default="stdio",
         choices=["stdio", "streamable-http"],
         help="MCP transport type (default: stdio for Claude Code)",
+    )
+    parser_mcp.add_argument(
+        "--harness",
+        help="Harness to index with (default: pytorch)",
+    )
+    parser_mcp.add_argument(
+        "--format",
+        default="compact",
+        choices=["compact", "markdown"],
+        help="Tool response format (default: compact)",
     )
     parser_mcp.add_argument("--debug", action="store_true", help="Enable debug logging")
     parser_mcp.set_defaults(func=cmd_mcp_serve)
@@ -753,7 +775,7 @@ First run builds the index (a few minutes); subsequent runs use cache.
         parser.print_help()
         sys.exit(1)
 
-    args.func(args)
+    sys.exit(args.func(args) or 0)
 
 
 if __name__ == "__main__":

--- a/src/torchtalk/formatting.py
+++ b/src/torchtalk/formatting.py
@@ -159,7 +159,11 @@ def relative_path(full_path: str, base: str | None = None) -> str:
 
     prefixes = ["pytorch/"]
     if base:
-        prefixes.insert(0, base.rstrip("/") + "/")
+        base_clean = base.rstrip("/")
+        prefixes.insert(0, base_clean + "/")
+        checkout_name = base_clean.rsplit("/", 1)[-1]
+        if checkout_name and f"{checkout_name}/" not in prefixes:
+            prefixes.append(f"{checkout_name}/")
 
     for prefix in prefixes:
         if full_path.startswith(prefix):
@@ -169,6 +173,8 @@ def relative_path(full_path: str, base: str | None = None) -> str:
 
 def coverage_note(extractor) -> str:
     """Return a one-line C++ TU coverage summary, or '' when empty."""
+    if extractor is None:
+        return ""
     cov = extractor.coverage_summary()
     if not cov:
         return ""
@@ -181,8 +187,14 @@ def coverage_note(extractor) -> str:
         return ""
     bits = []
     if unsupported:
-        bits.append(f"{unsupported:,} CUDA/.mm/.cc")
+        bits.append(f"{unsupported:,} unsupported")
     if parse_failed:
         bits.append(f"{parse_failed:,} parse-failed")
-    unindexed = f"; unindexed: {', '.join(bits)}" if bits else ""
+    comp = []
+    if cu := cov.get("cu_unindexed", 0):
+        comp.append(f"{cu:,} .cu")
+    if cc := cov.get("cc_unindexed", 0):
+        comp.append(f"{cc:,} .cc")
+    composition = f" (incl. {', '.join(comp)})" if comp else ""
+    unindexed = f"; unindexed: {', '.join(bits)}{composition}" if bits else ""
     return f"Coverage: {ok:,} of {total:,} C++ TUs indexed{unindexed}."

--- a/src/torchtalk/formatting.py
+++ b/src/torchtalk/formatting.py
@@ -159,11 +159,7 @@ def relative_path(full_path: str, base: str | None = None) -> str:
 
     prefixes = ["pytorch/"]
     if base:
-        base_clean = base.rstrip("/")
-        prefixes.insert(0, base_clean + "/")
-        checkout_name = base_clean.rsplit("/", 1)[-1]
-        if checkout_name and f"{checkout_name}/" not in prefixes:
-            prefixes.append(f"{checkout_name}/")
+        prefixes.insert(0, base.rstrip("/") + "/")
 
     for prefix in prefixes:
         if full_path.startswith(prefix):

--- a/src/torchtalk/indexer.py
+++ b/src/torchtalk/indexer.py
@@ -11,7 +11,7 @@ from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any
 
-from .analysis.helpers import levenshtein_distance, truncate
+from .analysis.helpers import fuzzy_distance_limit, levenshtein_distance, truncate
 from .analysis.patterns import (
     CPP_SEARCH_DIRS,
     PYTHON_SEARCH_DIRS,
@@ -391,8 +391,7 @@ def _fuzzy_find(name: str, data: dict[str, Any]) -> list[Any] | None:
         for key in data:
             if abs(len(key) - len(name)) <= 3:
                 dist = levenshtein_distance(name_lower, key.lower())
-                max_dist = min(3, max(2, len(name) // 3))
-                if dist <= max_dist:
+                if dist <= fuzzy_distance_limit(name):
                     candidates.append((dist, key, data[key]))
 
         if candidates:

--- a/src/torchtalk/indexer.py
+++ b/src/torchtalk/indexer.py
@@ -83,7 +83,17 @@ def _cache_path(source: str) -> Path:
 
 
 def _source_fingerprint(source: str) -> str:
-    """Fingerprint source to detect changes."""
+    """Fingerprint source to detect changes.
+
+    Git checkouts get a content fingerprint (HEAD tree + dirty diff), so
+    commits, pulls, and uncommitted edits all invalidate caches. Non-git
+    checkouts fall back to mtime/size of version files.
+    """
+    from .snapshots import _content_fingerprint
+
+    fp = _content_fingerprint(source) if source else None
+    if fp:
+        return fp
     src = Path(source)
     files = [
         src / "version.txt",
@@ -99,8 +109,18 @@ def _source_fingerprint(source: str) -> str:
 
 
 # Bump when the bindings-cache schema changes (e.g. a new field added to
-# `native_functions` entries). v2 introduced `python_module`.
-_BINDINGS_CACHE_FORMAT_VERSION = 2
+# `native_functions` entries). v2 introduced `python_module`; v3 renamed
+# binding "line" -> "line_number".
+_BINDINGS_CACHE_FORMAT_VERSION = 3
+
+
+def _cache_metadata(source: str) -> dict:
+    """Metadata every bindings-cache writer must emit; `_cache_valid` checks it."""
+    return {
+        "source_path": source,
+        "source_fingerprint": _source_fingerprint(source),
+        "format_version": _BINDINGS_CACHE_FORMAT_VERSION,
+    }
 
 
 def _cache_valid(cache: Path, source: str) -> bool:
@@ -237,14 +257,20 @@ def _impls_from_extractor(target: str) -> list[dict]:
 
     Hybrid path: catches definitions the regex pre-filter misses (deeply
     templated returns, signatures whose layout the regex can't span).
-    Returns [] when the extractor isn't ready.
+    Returns [] when the extractor isn't ready. Matches outside the indexed
+    source tree (stdlib/system headers the TU pulled in) are dropped.
     """
     extractor = _state.cpp_extractor
     if not extractor:
         return []
+    src_prefix = (
+        (_state.pytorch_source.rstrip("/") + "/") if _state.pytorch_source else None
+    )
     out: list[dict] = []
     for qname, (file, line) in extractor.function_locations.items():
         if qname.rsplit("::", 1)[-1] != target:
+            continue
+        if src_prefix and not file.startswith(src_prefix):
             continue
         out.append(
             {
@@ -344,13 +370,19 @@ def _fuzzy_find(name: str, data: dict[str, Any]) -> list[Any] | None:
 
     name_lower = name.lower()
 
-    for key in data:
-        if key.lower().endswith(name_lower) or key.lower().endswith(f"_{name_lower}"):
-            return data[key] if isinstance(data[key], list) else [data[key]]
+    suffix_keys = [
+        k
+        for k in data
+        if k.lower().endswith(name_lower) or k.lower().endswith(f"_{name_lower}")
+    ]
+    if suffix_keys:
+        # Deterministic: shortest key, lexicographic tiebreak (not dict order)
+        key = min(suffix_keys, key=lambda k: (len(k), k))
+        return data[key] if isinstance(data[key], list) else [data[key]]
 
     matches = [(k, v) for k, v in data.items() if name_lower in k.lower()]
     if matches:
-        matches.sort(key=lambda x: len(x[0]))
+        matches.sort(key=lambda x: (len(x[0]), x[0]))
         v = matches[0][1]
         return v if isinstance(v, list) else [v]
 
@@ -359,12 +391,12 @@ def _fuzzy_find(name: str, data: dict[str, Any]) -> list[Any] | None:
         for key in data:
             if abs(len(key) - len(name)) <= 3:
                 dist = levenshtein_distance(name_lower, key.lower())
-                max_dist = max(2, len(name) // 3)
+                max_dist = min(3, max(2, len(name) // 3))
                 if dist <= max_dist:
                     candidates.append((dist, key, data[key]))
 
         if candidates:
-            candidates.sort(key=lambda x: x[0])
+            candidates.sort(key=lambda x: (x[0], len(x[1]), x[1]))
             v = candidates[0][2]
             return v if isinstance(v, list) else [v]
 
@@ -392,11 +424,7 @@ def _build_index(source: str) -> dict[str, Any]:
         "derivatives": derivatives,
         "native_implementations": implementations,
         "symbol_to_file": symbol_to_file,
-        "metadata": {
-            "source_path": source,
-            "source_fingerprint": _source_fingerprint(source),
-            "format_version": _BINDINGS_CACHE_FORMAT_VERSION,
-        },
+        "metadata": _cache_metadata(source),
     }
 
     cache = _cache_path(source)
@@ -479,7 +507,9 @@ def _init_cpp_call_graph(source: str):
         cache_key = f"pytorch_callgraph_parallel_{source_hash(source)}"
 
         extractor = CppCallGraphExtractor(cache_dir=cg_cache_dir)
-        if extractor.load_cache(cache_key):
+        if extractor.load_cache(
+            cache_key, expect_fingerprint=_source_fingerprint(source)
+        ):
             _state.cpp_extractor = extractor
             log.info(
                 f"Loaded C++ call graph from cache "
@@ -495,7 +525,7 @@ def _init_cpp_call_graph(source: str):
             try:
                 ext = CppCallGraphExtractor(cache_dir=cg_cache_dir)
                 ext.extract_from_pytorch_parallel(source)
-                ext.save_cache(cache_key)
+                ext.save_cache(cache_key, fingerprint=_source_fingerprint(source))
                 _state.cpp_extractor = ext
                 log.info(
                     f"C++ call graph ready: {len(ext.function_locations)} functions"
@@ -1285,8 +1315,7 @@ def update_index(source: str, since: str, on_uncovered: str = "warn") -> dict:
         "native_implementations": implementations,
         "symbol_to_file": symbol_to_file,
         "metadata": {
-            "source_path": source,
-            "source_fingerprint": _source_fingerprint(source),
+            **_cache_metadata(source),
             "updated_since": since,
             "updated_commit": manifest.git_commit,
         },
@@ -1460,7 +1489,7 @@ def _update_call_graph(
     if uncovered and on_uncovered == "fail":
         stats["uncovered_fail"] = True
 
-    extractor.save_cache(cache_key)
+    extractor.save_cache(cache_key, fingerprint=_source_fingerprint(source))
     return stats
 
 

--- a/src/torchtalk/server.py
+++ b/src/torchtalk/server.py
@@ -64,6 +64,13 @@ async def get_status() -> str:
         )
     if _state.derivatives:
         md.bold("Derivatives", f"{len(_state.derivatives):,} formulas")
+    if _state.registrations:
+        md.bold(
+            "Registrations",
+            f"{len(_state.registrations.get('records', [])):,} records, "
+            f"{len(_state.registrations.get('candidate_edges', [])):,} "
+            "candidate edges",
+        )
     md.blank()
 
     md.h3("C++ Call Graph")
@@ -232,7 +239,8 @@ async def graph(
 
     mode='callers' for inbound, 'calls' for outbound, 'impact' for transitive
     callers. `depth`, `fuzzy_all_levels`, `walk_python`, and `focus` apply to
-    mode='impact' only and are ignored otherwise. `focus='full'` adds a
+    mode='impact' only and are ignored otherwise. `depth` is clamped to 5
+    (raise via TORCHTALK_GRAPH_MAX_DEPTH, hard cap 10). `focus='full'` adds a
     Python Entry Points section listing each walked C++ symbol's binding.
     """
     if mode == "calls":

--- a/src/torchtalk/server.py
+++ b/src/torchtalk/server.py
@@ -64,13 +64,6 @@ async def get_status() -> str:
         )
     if _state.derivatives:
         md.bold("Derivatives", f"{len(_state.derivatives):,} formulas")
-    if _state.registrations:
-        md.bold(
-            "Registrations",
-            f"{len(_state.registrations.get('records', [])):,} records, "
-            f"{len(_state.registrations.get('candidate_edges', [])):,} "
-            "candidate edges",
-        )
     md.blank()
 
     md.h3("C++ Call Graph")

--- a/src/torchtalk/tools/affected.py
+++ b/src/torchtalk/tools/affected.py
@@ -5,6 +5,26 @@ from __future__ import annotations
 from ..analysis.affected import affected_tests
 from ..formatting import create_formatter
 from ..indexer import _cpp_status, _ensure_loaded, _state
+from .graph import _max_depth
+
+
+def _split_funcs(funcs: str) -> list[str]:
+    """Split on commas outside angle brackets so template args stay intact."""
+    out: list[str] = []
+    buf: list[str] = []
+    nesting = 0
+    for ch in funcs:
+        if ch == "<":
+            nesting += 1
+        elif ch == ">":
+            nesting = max(0, nesting - 1)
+        if ch == "," and nesting == 0:
+            out.append("".join(buf).strip())
+            buf = []
+        else:
+            buf.append(ch)
+    out.append("".join(buf).strip())
+    return [f for f in out if f]
 
 
 async def _do_affected(funcs: str, depth: int = 3) -> str:
@@ -12,9 +32,11 @@ async def _do_affected(funcs: str, depth: int = 3) -> str:
     if status := _cpp_status():
         return status
 
-    func_list = [f.strip() for f in funcs.split(",") if f.strip()]
+    func_list = _split_funcs(funcs)
     if not func_list:
         return "No functions provided."
+
+    depth = min(max(depth, 1), _max_depth())
 
     result = affected_tests(
         funcs=func_list,

--- a/src/torchtalk/tools/affected.py
+++ b/src/torchtalk/tools/affected.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from ..analysis.affected import affected_tests
 from ..formatting import create_formatter
 from ..indexer import _cpp_status, _ensure_loaded, _state
-from .graph import _max_depth
+from .graph import _clamp_depth
 
 
 def _split_funcs(funcs: str) -> list[str]:
@@ -36,7 +36,7 @@ async def _do_affected(funcs: str, depth: int = 3) -> str:
     if not func_list:
         return "No functions provided."
 
-    depth = min(max(depth, 1), _max_depth())
+    depth = _clamp_depth(depth)
 
     result = affected_tests(
         funcs=func_list,

--- a/src/torchtalk/tools/common.py
+++ b/src/torchtalk/tools/common.py
@@ -1,0 +1,15 @@
+"""Helpers shared across tool modules."""
+
+from __future__ import annotations
+
+from ..formatting import coverage_note, relative_path
+from ..indexer import _state
+
+
+def _rel_path(path: str) -> str:
+    return relative_path(path, _state.pytorch_source)
+
+
+def _with_note(text: str) -> str:
+    note = coverage_note(_state.cpp_extractor)
+    return f"{text}\n\n{note}" if note else text

--- a/src/torchtalk/tools/graph.py
+++ b/src/torchtalk/tools/graph.py
@@ -72,6 +72,48 @@ def _with_note(text: str) -> str:
     return f"{text}\n\n{note}" if note else text
 
 
+def _cuda_gap_note() -> str:
+    cu = _state.cpp_extractor.coverage_summary().get("cu_unindexed", 0)
+    return f"{cu:,} .cu TUs unindexed — CUDA callers unknown." if cu else ""
+
+
+def _cuda_adjacent(function_name: str, items: list[dict], file_key: str) -> bool:
+    if "cuda" in function_name.lower():
+        return True
+    return any(
+        (it.get(file_key) or "").lower().endswith((".cu", ".cuh"))
+        or "cuda" in (it.get(file_key) or "").lower()
+        for it in items
+    )
+
+
+def _resolve_function(
+    function_name: str, relation: str = "callers"
+) -> tuple[str | None, str]:
+    """Resolve a query to ONE call-graph symbol, disclosing fuzzy resolution.
+
+    Ranked candidates come from match_functions; the first one with any
+    relations in the requested direction wins (deterministic). Only that
+    symbol is queried — candidates are listed in the note instead of
+    silently merging every match's neighborhood.
+    """
+    ext = _state.cpp_extractor
+    matches = ext.match_functions(function_name, fuzzy=True)
+    if not matches:
+        return None, ""
+    getter = ext.get_callees if relation == "callees" else ext.get_callers
+    resolved = next((m for m in matches if getter(m, fuzzy=False)), matches[0])
+    if resolved == function_name:
+        return resolved, ""
+    note = f"Resolved '{function_name}' → '{resolved}' (fuzzy)."
+    others = [m for m in matches if m != resolved]
+    if others:
+        shown = ", ".join(f"`{m}`" for m in others[:8])
+        more = f", +{len(others) - 8} more" if len(others) > 8 else ""
+        note += f" Other matches: {shown}{more}."
+    return resolved, note
+
+
 def _format_call_item(md, item: dict, name_key: str, file_key: str, line_key: str):
     name = item[name_key]
     if file_path := item.get(file_key):
@@ -83,17 +125,27 @@ def _format_call_item(md, item: dict, name_key: str, file_key: str, line_key: st
 
 async def _do_calls(function_name: str) -> str:
     _ensure_loaded()
+    if not function_name.strip():
+        return "Provide a function name."
     if status := _cpp_status():
         return status
 
-    callees = _state.cpp_extractor.get_callees(function_name, fuzzy=True)
+    resolved, note = _resolve_function(function_name, relation="callees")
+    callees = (
+        _state.cpp_extractor.get_callees(resolved, fuzzy=False) if resolved else []
+    )
     if not callees:
-        return _with_note(f"No outbound calls found for '{function_name}'.")
+        msg = f"No outbound calls found for '{function_name}'."
+        if note:
+            msg = f"{msg}\n\n{note}"
+        return _with_note(msg)
 
     results = dedupe_by_key(callees, "callee")
 
     md = create_formatter()
     md.h2(f"Calls: `{function_name}`")
+    if note:
+        md.text(note)
     md.text("*Functions this calls (outbound dependencies):*\n")
 
     for item in results[:15]:
@@ -107,17 +159,29 @@ async def _do_calls(function_name: str) -> str:
 
 async def _do_called_by(function_name: str) -> str:
     _ensure_loaded()
+    if not function_name.strip():
+        return "Provide a function name."
     if status := _cpp_status():
         return status
 
-    callers = _state.cpp_extractor.get_callers(function_name, fuzzy=True)
+    resolved, note = _resolve_function(function_name)
+    callers = (
+        _state.cpp_extractor.get_callers(resolved, fuzzy=False) if resolved else []
+    )
     if not callers:
-        return _with_note(f"No inbound callers found for '{function_name}'.")
+        msg = f"No inbound callers found for '{function_name}'."
+        if note:
+            msg = f"{msg}\n\n{note}"
+        if gap := _cuda_gap_note():
+            msg = f"{msg}\n\n{gap}"
+        return _with_note(msg)
 
     results = dedupe_by_key(callers, "caller")
 
     md = create_formatter()
     md.h2(f"Called by: `{function_name}`")
+    if note:
+        md.text(note)
     md.text("*Functions that call this (inbound dependents):*\n")
 
     for item in results[:15]:
@@ -125,6 +189,12 @@ async def _do_called_by(function_name: str) -> str:
 
     if len(results) > 15:
         md.text(f"\n*Showing 15 of {len(results)} callers.*")
+
+    if _cuda_adjacent(function_name, results, "caller_file") and (
+        gap := _cuda_gap_note()
+    ):
+        md.blank()
+        md.text(gap)
 
     return _with_note(md.build())
 
@@ -137,13 +207,19 @@ async def _do_impact(
     walk_python: bool = False,
 ) -> str:
     _ensure_loaded()
+    if not function_name.strip():
+        return "Provide a function name."
     if status := _cpp_status():
         return status
 
     depth = min(max(depth, 1), _max_depth())
 
+    resolved, note = _resolve_function(function_name)
+    if resolved is None:
+        return _with_note(f"No callers found for '{function_name}'.")
+
     visited = set()
-    current_level = {function_name}
+    current_level = {resolved}
     callers_by_depth: dict[int, list[dict]] = {}
 
     for level in range(1, depth + 1):
@@ -151,10 +227,11 @@ async def _do_impact(
         level_callers = []
 
         for func in current_level:
-            fuzzy = fuzzy_all_levels or level == 1
+            # Level 1 fuzziness is handled by the up-front resolution.
+            fuzzy = fuzzy_all_levels and level > 1
             for item in _state.cpp_extractor.get_callers(func, fuzzy=fuzzy):
                 caller = item["caller"]
-                if caller not in visited and caller != function_name:
+                if caller not in visited and caller not in (function_name, resolved):
                     visited.add(caller)
                     next_level.add(caller)
                     level_callers.append(item)
@@ -166,10 +243,15 @@ async def _do_impact(
             break
 
     if not callers_by_depth:
-        return _with_note(f"No callers found for '{function_name}'.")
+        msg = f"No callers found for '{function_name}'."
+        if note:
+            msg = f"{msg}\n\n{note}"
+        return _with_note(msg)
 
     md = create_formatter()
     md.h2(f"Impact Analysis: `{function_name}`")
+    if note:
+        md.text(note)
     md.text(f"*Tracing callers up to {depth} levels deep*\n")
 
     total = 0
@@ -185,6 +267,10 @@ async def _do_impact(
             md.item(f"*... and {len(unique) - 15} more*")
         md.blank()
 
+    # Both Python-facing sections must include the seed itself — a query on
+    # `at::native::gelu` has entry points/py-callers even with zero C++ callers.
+    impact_set = visited | {function_name, resolved}
+
     if focus == "full":
         python_entries = [
             {
@@ -192,7 +278,7 @@ async def _do_impact(
                 "cpp": c,
                 "dispatch": b.get("dispatch_key", ""),
             }
-            for c in visited
+            for c in impact_set
             if c in _state.by_cpp_name
             for b in _state.by_cpp_name[c][:1]
         ]
@@ -210,7 +296,7 @@ async def _do_impact(
         # Python wrappers that don't go through a registered binding.
         seen_callers: set[tuple[str, str, int]] = set()
         py_callers: list[dict] = []
-        for cpp in visited:
+        for cpp in impact_set:
             for hit in _python_callers_for(cpp):
                 key = (hit["caller_qualname"], hit["file"], hit["line"])
                 if key in seen_callers:

--- a/src/torchtalk/tools/graph.py
+++ b/src/torchtalk/tools/graph.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 import os
 
 from ..analysis.helpers import dedupe_by_key
-from ..formatting import coverage_note, create_formatter, relative_path
+from ..formatting import create_formatter
 from ..indexer import _cpp_status, _ensure_loaded, _state
+from .common import _rel_path, _with_note
 
 # Hard ceiling on impact-walk depth. Power users can raise the soft default
 # via the TORCHTALK_GRAPH_MAX_DEPTH env var, but never above this cap —
@@ -22,6 +23,10 @@ def _max_depth() -> int:
         return max(1, min(int(raw), _GRAPH_HARD_DEPTH_CAP))
     except ValueError:
         return 5
+
+
+def _clamp_depth(depth: int) -> int:
+    return min(max(depth, 1), _max_depth())
 
 
 def _py_name_to_cpp_symbol(py_name: str) -> str:
@@ -61,15 +66,6 @@ def _python_callers_for(cpp_func: str) -> list[dict]:
         seen_keys.add(key)
         out.extend(edges.get(key, []))
     return out
-
-
-def _rel_path(path: str) -> str:
-    return relative_path(path, _state.pytorch_source)
-
-
-def _with_note(text: str) -> str:
-    note = coverage_note(_state.cpp_extractor)
-    return f"{text}\n\n{note}" if note else text
 
 
 def _cuda_gap_note() -> str:
@@ -212,7 +208,7 @@ async def _do_impact(
     if status := _cpp_status():
         return status
 
-    depth = min(max(depth, 1), _max_depth())
+    depth = _clamp_depth(depth)
 
     resolved, note = _resolve_function(function_name)
     if resolved is None:

--- a/src/torchtalk/tools/modules.py
+++ b/src/torchtalk/tools/modules.py
@@ -3,12 +3,9 @@
 from __future__ import annotations
 
 from ..analysis.helpers import fuzzy_match
-from ..formatting import create_formatter, relative_path
+from ..formatting import create_formatter
 from ..indexer import _ensure_loaded, _state
-
-
-def _rel_path(path: str) -> str:
-    return relative_path(path, _state.pytorch_source)
+from .common import _rel_path
 
 
 async def _do_trace_module(module_name: str, focus: str = "methods") -> str:

--- a/src/torchtalk/tools/modules.py
+++ b/src/torchtalk/tools/modules.py
@@ -17,6 +17,9 @@ async def _do_trace_module(module_name: str, focus: str = "methods") -> str:
     if not _state.py_classes:
         return "Python module analysis not available. Ensure PyTorch source is loaded."
 
+    if not module_name.strip():
+        return "Provide a module or class name."
+
     search_name = module_name.split(".")[-1]
 
     exact_matches = []
@@ -89,21 +92,12 @@ async def _do_list_modules(category: str = "nn") -> str:
         modules = sorted(_state.nn_modules, key=lambda x: x.name)
         md.text(f"Found {len(modules)} nn.Module subclasses\n")
 
-        # Group by type
-        layers = [
-            m
-            for m in modules
-            if not any(x in m.name for x in ["Loss", "Container", "Sequential"])
-        ]
+        # Group by type — buckets must partition (no double-count)
+        container_markers = ["Container", "Sequential", "ModuleList", "ModuleDict"]
         losses = [m for m in modules if "Loss" in m.name]
-        containers = [
-            m
-            for m in modules
-            if any(
-                x in m.name
-                for x in ["Container", "Sequential", "ModuleList", "ModuleDict"]
-            )
-        ]
+        containers = [m for m in modules if any(x in m.name for x in container_markers)]
+        grouped = {m.name for m in losses} | {m.name for m in containers}
+        layers = [m for m in modules if m.name not in grouped]
 
         if layers:
             md.h3(f"Layers ({len(layers)})")
@@ -128,10 +122,14 @@ async def _do_list_modules(category: str = "nn") -> str:
             cls
             for name, classes in _state.py_classes.items()
             for cls in classes
-            if "optim" in cls.qualified_name.lower() and not name.startswith("_")
+            if cls.qualified_name.lower().startswith("torch.optim.")
+            and not name.startswith("_")
         ]
-        for cls in sorted(optim_classes, key=lambda x: x.name)[:20]:
+        ranked = sorted(optim_classes, key=lambda x: x.name)
+        for cls in ranked[:20]:
             md.item(f"`{cls.name}` - {cls.qualified_name}")
+        if len(ranked) > 20:
+            md.item(f"*... and {len(ranked) - 20} more.*")
 
     elif category == "all":
         md.h2("All Python Classes")

--- a/src/torchtalk/tools/ops.py
+++ b/src/torchtalk/tools/ops.py
@@ -5,17 +5,9 @@ from __future__ import annotations
 from typing import Literal
 
 from ..analysis.helpers import safe_sort_key, truncate
-from ..formatting import coverage_note, create_formatter, relative_path
+from ..formatting import create_formatter
 from ..indexer import _ensure_loaded, _fuzzy_find, _impls_from_extractor, _state
-
-
-def _with_note(text: str) -> str:
-    note = coverage_note(_state.cpp_extractor)
-    return f"{text}\n\n{note}" if note else text
-
-
-def _rel_path(path: str) -> str:
-    return relative_path(path, _state.pytorch_source)
+from .common import _rel_path, _with_note
 
 
 def _get_native_func(name: str) -> dict | None:

--- a/src/torchtalk/tools/ops.py
+++ b/src/torchtalk/tools/ops.py
@@ -66,6 +66,8 @@ async def trace(
 ) -> str:
     """Trace a PyTorch op from Python to C++ implementation with file:line locations."""
     _ensure_loaded()
+    if not function_name.strip():
+        return "Provide a function name to trace."
 
     md = create_formatter()
     md.h2(f"Trace: `{function_name}`")
@@ -106,6 +108,8 @@ async def trace(
                 md.item(f"`{input_name}`: `{truncate(formula, 60)}`")
             md.blank()
 
+    bindings: list[dict] = []
+    fuzzy_bindings = False
     if focus in ("full", "dispatch"):
         # From binding detector (TORCH_LIBRARY_IMPL registrations)
         bindings = _state.by_python_name.get(function_name, [])
@@ -115,9 +119,13 @@ async def trace(
             found = _fuzzy_find(function_name, _state.by_python_name)
             if found:
                 bindings = found
+                fuzzy_bindings = True
 
         if bindings:
-            md.h3("Dispatch Registrations (TORCH_LIBRARY_IMPL)")
+            title = "Dispatch Registrations (TORCH_LIBRARY_IMPL)"
+            if fuzzy_bindings:
+                title += " — fuzzy match"
+            md.h3(title)
             rows = []
             seen = set()
             for b in bindings:
@@ -176,9 +184,11 @@ async def trace(
                 impls.append(impl)
 
         if impls:
-            md.h3("C++ Implementations")
+            # Dedupe BEFORE slicing: dispatch `.values()` repeats the same
+            # impl per dispatch key, which starved the visible list.
             seen = set()
-            for impl in impls[:10]:
+            unique_impls = []
+            for impl in impls:
                 key = (
                     impl["function_name"],
                     impl.get("file_path"),
@@ -187,16 +197,18 @@ async def trace(
                 if key in seen:
                     continue
                 seen.add(key)
+                unique_impls.append(impl)
 
+            md.h3("C++ Implementations")
+            for impl in unique_impls[:10]:
                 path = _rel_path(impl.get("file_path", ""))
                 line = impl.get("line_number", "")
                 md.item(f"`{impl['function_name']}` → `{path}:{line}`")
+            if len(unique_impls) > 10:
+                md.item(f"*... and {len(unique_impls) - 10} more*")
             md.blank()
 
-    bindings_found = _state.by_python_name.get(function_name) or _state.by_cpp_name.get(
-        function_name
-    )
-    found_anything = native or bindings_found or impls
+    found_anything = native or bindings or impls
 
     if not found_anything:
         similar = _similar_functions(function_name)
@@ -213,6 +225,7 @@ async def trace(
 
 async def _do_cuda_kernels(query: str = "", limit: int = 15) -> str:
     _ensure_loaded()
+    limit = max(1, limit)
 
     md = create_formatter()
     title = f"CUDA Kernels: '{query}'" if query else "CUDA Kernels"
@@ -248,6 +261,9 @@ async def _do_cuda_kernels(query: str = "", limit: int = 15) -> str:
 
 async def _do_search_bindings(query: str, backend: str = "", limit: int = 10) -> str:
     _ensure_loaded()
+    if not query.strip():
+        return "Provide a query string to search bindings."
+    limit = max(1, limit)
 
     query_lower = query.lower()
     backend_lower = backend.lower() if backend else ""

--- a/src/torchtalk/tools/tests.py
+++ b/src/torchtalk/tools/tests.py
@@ -5,12 +5,8 @@ from __future__ import annotations
 from pathlib import Path
 
 from ..analysis.helpers import word_match as _word_match
-from ..formatting import create_formatter, relative_path
+from ..formatting import create_formatter
 from ..indexer import _ensure_loaded, _state
-
-
-def _rel_path(path: str) -> str:
-    return relative_path(path, _state.pytorch_source)
 
 
 async def _do_find_similar_tests(

--- a/src/torchtalk/tools/tests.py
+++ b/src/torchtalk/tools/tests.py
@@ -4,26 +4,13 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from ..analysis.helpers import word_match as _word_match
 from ..formatting import create_formatter, relative_path
 from ..indexer import _ensure_loaded, _state
 
 
 def _rel_path(path: str) -> str:
     return relative_path(path, _state.pytorch_source)
-
-
-def _word_match(query_lower: str, name_lower: str) -> bool:
-    """Match on word boundaries to avoid 'add' matching 'padding'."""
-    idx = name_lower.find(query_lower)
-    if idx == -1:
-        return False
-    before = name_lower[idx - 1] if idx > 0 else "_"
-    after = (
-        name_lower[idx + len(query_lower)]
-        if idx + len(query_lower) < len(name_lower)
-        else "_"
-    )
-    return not before.isalpha() and not after.isalpha()
 
 
 async def _do_find_similar_tests(
@@ -35,6 +22,7 @@ async def _do_find_similar_tests(
     # would match every indexed file — refuse rather than dump 1k+ paths.
     if not query.strip():
         return "Provide a query string to search tests."
+    limit = max(1, limit)
 
     query_lower = query.lower()
     md = create_formatter()
@@ -238,6 +226,8 @@ async def _do_list_test_utils() -> str:
 
 async def _do_test_file_info(query: str) -> str:
     _ensure_loaded("test")
+    if not query.strip():
+        return "Provide a test file name."
 
     needle = query.lower()
     matches = []

--- a/tests/test_affected.py
+++ b/tests/test_affected.py
@@ -19,7 +19,7 @@ from torchtalk.analysis.affected import (
     normalize_api,
     symbols_in_file,
 )
-from torchtalk.tools.affected import _do_affected
+from torchtalk.tools.affected import _do_affected, _split_funcs
 
 
 class TestNormalizeApi:
@@ -1618,3 +1618,53 @@ class TestAffectedTool:
         result = asyncio.run(_do_affected("foo_kernel"))
         # 12 fuzzy helpers -> preview shows 10 with `+2 more`.
         assert "+2 more" in result
+
+
+class TestSplitFuncs:
+    def test_comma_inside_template_args_not_split(self):
+        assert _split_funcs("vec<T, N>::store, at::native::gelu") == [
+            "vec<T, N>::store",
+            "at::native::gelu",
+        ]
+
+    def test_plain_csv(self):
+        assert _split_funcs(" a , b ") == ["a", "b"]
+
+    def test_nested_templates(self):
+        assert _split_funcs("f<a<b, c>, d>, g") == ["f<a<b, c>, d>", "g"]
+
+    def test_empty_tokens_dropped(self):
+        assert _split_funcs(",foo,,") == ["foo"]
+
+
+class TestAffectedDepthClamp:
+    def test_depth_clamped_like_graph(self, monkeypatch):
+        from unittest.mock import MagicMock
+
+        from torchtalk import indexer
+        from torchtalk.tools import affected as affected_tool
+
+        ext = MagicMock()
+        ext.get_callers.return_value = []
+        monkeypatch.setattr(indexer._state, "bindings", [{"x": 1}])
+        monkeypatch.setattr(indexer._state, "cpp_extractor", ext)
+        captured = {}
+
+        def fake_affected_tests(**kwargs):
+            captured.update(kwargs)
+            return {
+                "callers_walked": 0,
+                "bindings_matched": [],
+                "python_apis": [],
+                "api_sources": {},
+                "api_tier": {},
+                "test_runs": [],
+            }
+
+        monkeypatch.setattr(affected_tool, "affected_tests", fake_affected_tests)
+        monkeypatch.delenv("TORCHTALK_GRAPH_MAX_DEPTH", raising=False)
+
+        asyncio.run(_do_affected("foo", depth=-1))
+        assert captured["depth"] == 1
+        asyncio.run(_do_affected("foo", depth=99))
+        assert captured["depth"] == 5

--- a/tests/test_binding_detector.py
+++ b/tests/test_binding_detector.py
@@ -219,3 +219,86 @@ class TestCudaDeviceFuncBinding:
             if b.binding_type == BindingType.CUDA_DEVICE_FUNC.value
         ]
         assert device_bindings == []
+
+
+class TestModuleVarTorchOps:
+    def test_library_block_uses_declared_module_variable(self):
+        code = (
+            "TORCH_LIBRARY(myns, lib) {\n"
+            '  lib.def("custom_op(Tensor t) -> Tensor");\n'
+            "}\n"
+        )
+        graph = BindingDetector().detect_bindings("/v.cpp", code)
+        assert any(b.python_name == "myns.custom_op" for b in graph.bindings)
+
+
+class TestBindingToDict:
+    def test_emits_line_number_key(self):
+        from torchtalk.analysis.binding_detector import Binding
+
+        d = Binding(
+            python_name="x",
+            cpp_name="x",
+            binding_type="torch_op",
+            file_path="/f.cpp",
+            line_number=7,
+        ).to_dict()
+        assert d["line_number"] == 7
+        assert "line" not in d
+
+
+class TestStandalonePybindBounds:
+    def test_def_chain_bounded_by_semicolon(self):
+        code = (
+            'py::class_<Foo>(m, "Foo")\n'
+            '    .def("real_method", &Foo::real_method);\n'
+            "\n"
+            'm.def("unrelated_fn", &unrelated_fn);\n'
+            'other.attr("x").def("phantom_method", &Bar::phantom);\n'
+        )
+        graph = BindingDetector().detect_bindings("/x.cpp", code)
+        names = {b.python_name for b in graph.bindings}
+        assert "Foo.real_method" in names
+        assert "Foo.phantom_method" not in names
+
+    def test_module_region_not_double_extracted(self):
+        code = (
+            "PYBIND11_MODULE(mymod, m) {\n"
+            '  py::class_<Foo>(m, "Foo")\n'
+            '      .def("method_a", &Foo::method_a);\n'
+            "}\n"
+        )
+        graph = BindingDetector().detect_bindings("/y.cpp", code)
+        rows = [
+            (b.python_name, b.binding_type)
+            for b in graph.bindings
+            if b.python_name == "Foo.method_a"
+        ]
+        assert len(rows) == 1
+
+
+class TestEnclosingFunctionKeywords:
+    def test_kernel_launch_inside_if_attributes_to_function(self):
+        code = (
+            "__global__ void my_kernel(float* x) {}\n"
+            "void launch_my_kernel(float* x) {\n"
+            "  if (x != nullptr) {\n"
+            "    my_kernel<<<1, 1>>>(x);\n"
+            "  }\n"
+            "}\n"
+        )
+        graph = BindingDetector().detect_bindings("/k.cu", code)
+        kernel = next(k for k in graph.cuda_kernels if k.name == "my_kernel")
+        assert kernel.called_by == ["launch_my_kernel"]
+
+    def test_at_dispatch_inside_for_not_named_for(self):
+        code = (
+            "void gelu_impl(Tensor& t) {\n"
+            "  for (int i = 0; i < 2; i++) {\n"
+            '    AT_DISPATCH_FLOATING_TYPES(t.scalar_type(), "gelu", [&] {});\n'
+            "  }\n"
+            "}\n"
+        )
+        graph = BindingDetector().detect_bindings("/d.cpp", code)
+        disp = next(b for b in graph.bindings if b.binding_type == "at_dispatch")
+        assert disp.cpp_name == "gelu_impl"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -143,3 +143,58 @@ class TestReadCacheStats:
         path = tmp_path / "cg.json"
         path.write_text("not json")
         assert _read_cache_stats(path) is None
+
+
+class TestMainExitCode:
+    """main() must propagate cmd_* return codes as process exit codes."""
+
+    def test_failing_command_exits_1(self, tmp_path, monkeypatch):
+        import pytest
+
+        from torchtalk import cli as cli_module
+        from torchtalk import snapshots
+
+        monkeypatch.setattr(snapshots, "SNAPSHOTS_DIR", tmp_path / "snapshots")
+        monkeypatch.setattr(
+            "sys.argv", ["torchtalk", "snapshot", "delete", "nonexistent"]
+        )
+        with pytest.raises(SystemExit) as exc:
+            cli_module.main()
+        assert exc.value.code == 1
+
+    def test_succeeding_command_exits_0(self, tmp_path, monkeypatch, capsys):
+        import pytest
+
+        from torchtalk import cli as cli_module
+        from torchtalk import snapshots
+
+        monkeypatch.setattr(snapshots, "SNAPSHOTS_DIR", tmp_path / "snapshots")
+        monkeypatch.setattr("sys.argv", ["torchtalk", "snapshot", "list"])
+        with pytest.raises(SystemExit) as exc:
+            cli_module.main()
+        assert exc.value.code == 0
+        assert "No snapshots found" in capsys.readouterr().out
+
+
+class TestFormatFlag:
+    def test_mcp_serve_wires_formatter_mode(self, monkeypatch):
+        from torchtalk import cli as cli_module
+        from torchtalk import formatting
+
+        monkeypatch.setattr("torchtalk.server.run_server", lambda **kw: None)
+        args = type(
+            "A",
+            (),
+            {
+                "harness": None,
+                "format": "markdown",
+                "pytorch_source": None,
+                "index": None,
+                "transport": "stdio",
+            },
+        )()
+        try:
+            cli_module.cmd_mcp_serve(args)
+            assert isinstance(formatting.create_formatter(), formatting.Markdown)
+        finally:
+            formatting.set_formatter_mode("compact")

--- a/tests/test_cpp_call_graph.py
+++ b/tests/test_cpp_call_graph.py
@@ -42,10 +42,10 @@ class TestTranslateArgs:
         out = _translate_args("/x.cpp", raw, cuda_env=None)
         assert out == ["-I/foo", "-DBAR=1", "-std=c++17"]
 
-    def test_cu_without_cuda_env_falls_back_to_cpp_filter(self):
+    def test_cu_without_cuda_env_parses_host_side_as_cpp(self):
         raw = ["-O2", "-I/foo", "-DBAR=1", "-std=c++17"]
         out = _translate_args("/x.cu", raw, cuda_env=None)
-        assert out == ["-I/foo", "-DBAR=1", "-std=c++17"]
+        assert out == ["-x", "c++", "-I/foo", "-DBAR=1", "-std=c++17"]
 
     def test_cu_with_cuda_env_emits_cuda_flag_stack(self):
         env = {
@@ -452,6 +452,7 @@ class TestTuStatus:
             "parse_failed": 1,
             "unsupported_language": 1,
             "filtered": 3,
+            "cu_unindexed": 1,
         }
 
     def test_coverage_summary_empty_when_no_tus_tracked(self, extractor):
@@ -612,3 +613,233 @@ class TestIncludeDirsPersistence:
         )
         assert extractor.load_from_path(legacy)
         assert extractor.include_dirs == []
+
+
+class _FakePool:
+    def __init__(self, processes=None):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def map(self, fn, items):
+        return [fn(i) for i in items]
+
+
+class TestSupportedExtensions:
+    """.cc/.cxx parse like .cpp; .cu is attempted even without a CUDA env."""
+
+    def test_cc_cxx_cu_are_parsed_without_cuda_env(
+        self, extractor, tmp_path, monkeypatch
+    ):
+        src = tmp_path / "repo"
+        (src / "src").mkdir(parents=True)
+        db = []
+        for name in ("a.cpp", "b.cc", "c.cxx", "d.cu", "e.mm"):
+            p = src / "src" / name
+            p.write_text("")
+            db.append({"file": str(p), "directory": str(src), "command": f"c++ {p}"})
+        (src / "compile_commands.json").write_text(json.dumps(db))
+
+        monkeypatch.setattr(cpp_call_graph, "_discover_cuda_env", lambda: None)
+        monkeypatch.setattr(cpp_call_graph, "should_exclude", lambda _p: False)
+        monkeypatch.setattr(cpp_call_graph, "should_include_dir", lambda _p, _d: True)
+        monkeypatch.setattr(cpp_call_graph, "Pool", _FakePool)
+
+        parsed: list[str] = []
+
+        def fake_parse(args):
+            fp, _ = args
+            parsed.append(fp)
+            return {
+                "file": fp,
+                "callees": {},
+                "callers": {},
+                "function_locations": {},
+                "includes": [],
+                "success": True,
+                "error": None,
+            }
+
+        monkeypatch.setattr(cpp_call_graph, "_parse_single_file", fake_parse)
+
+        extractor.extract_from_pytorch_parallel(str(src), num_workers=2)
+
+        names = {p.rsplit("/", 1)[-1] for p in parsed}
+        assert names == {"a.cpp", "b.cc", "c.cxx", "d.cu"}
+        assert extractor.tu_status["src/e.mm"] == "unsupported_language"
+        for parsed_tu in ("src/a.cpp", "src/b.cc", "src/c.cxx", "src/d.cu"):
+            assert extractor.tu_status[parsed_tu] == "ok"
+
+
+class TestCoverageSummaryComposition:
+    def test_reports_unindexed_cu_and_cc_counts(self, extractor):
+        extractor.tu_status = {
+            "src/a.cpp": "ok",
+            "src/k.cu": "parse_failed",
+            "src/l.cu": "unsupported_language",
+            "src/m.cc": "parse_failed",
+            "src/n.mm": "unsupported_language",
+            "src/o.cu": "ok",
+        }
+        cov = extractor.coverage_summary()
+        assert cov["cu_unindexed"] == 2
+        assert cov["cc_unindexed"] == 1
+        assert cov["ok"] == 2
+        assert cov["parse_failed"] == 2
+        assert cov["unsupported_language"] == 2
+
+    def test_fully_indexed_has_no_composition_keys(self, extractor):
+        extractor.tu_status = {"src/a.cpp": "ok", "src/d.cu": "ok"}
+        cov = extractor.coverage_summary()
+        assert "cu_unindexed" not in cov
+        assert "cc_unindexed" not in cov
+
+
+class TestHeaderStaleEdgeEviction:
+    """update_files must evict header-owned records the re-parse observes."""
+
+    def test_removed_header_edge_gone_after_update(self, extractor, monkeypatch):
+        _seed(
+            extractor,
+            {
+                "/B.h": {
+                    "callees": {"inline_fn": ["old_callee", "kept_callee"]},
+                    "callers": {
+                        "old_callee": ["inline_fn"],
+                        "kept_callee": ["inline_fn"],
+                    },
+                    "function_locations": {"inline_fn": ("/B.h", 3)},
+                },
+                "/C.h": {
+                    "callees": {"other_fn": ["x"]},
+                    "callers": {"x": ["other_fn"]},
+                    "function_locations": {"other_fn": ("/C.h", 1)},
+                },
+            },
+        )
+
+        def fake_parse(args):
+            return {
+                "file": "/A.cpp",
+                "callees": {"inline_fn": ["kept_callee"]},
+                "callers": {"kept_callee": ["inline_fn"]},
+                "function_locations": {"inline_fn": ("/B.h", 3)},
+                "includes": [],
+                "success": True,
+                "error": None,
+            }
+
+        monkeypatch.setattr(cpp_call_graph, "_parse_single_file", fake_parse)
+        extractor.update_files(entries=[("/A.cpp", [])])
+
+        assert "old_callee" not in extractor.callees["inline_fn"]
+        assert "kept_callee" in extractor.callees["inline_fn"]
+        assert "inline_fn" not in extractor.callers.get("old_callee", set())
+
+    def test_unobserved_header_records_survive(self, extractor, monkeypatch):
+        _seed(
+            extractor,
+            {
+                "/C.h": {
+                    "callees": {"other_fn": ["x"]},
+                    "callers": {"x": ["other_fn"]},
+                    "function_locations": {"other_fn": ("/C.h", 1)},
+                },
+            },
+        )
+
+        def fake_parse(args):
+            return {
+                "file": "/A.cpp",
+                "callees": {"tu_fn": ["y"]},
+                "callers": {"y": ["tu_fn"]},
+                "function_locations": {"tu_fn": ("/A.cpp", 10)},
+                "includes": [],
+                "success": True,
+                "error": None,
+            }
+
+        monkeypatch.setattr(cpp_call_graph, "_parse_single_file", fake_parse)
+        extractor.update_files(entries=[("/A.cpp", [])])
+
+        assert "x" in extractor.callees["other_fn"]
+        assert "other_fn" in extractor.callers["x"]
+
+
+class TestCacheFingerprint:
+    """Call-graph cache must self-invalidate when source content changes."""
+
+    def _seeded(self, extractor):
+        _seed(
+            extractor,
+            {
+                "/a.cpp": {
+                    "callees": {"f": ["g"]},
+                    "callers": {"g": ["f"]},
+                    "function_locations": {"f": ("/a.cpp", 1)},
+                }
+            },
+        )
+        return extractor
+
+    def test_mismatched_fingerprint_rejected(self, extractor, tmp_path):
+        self._seeded(extractor).save_cache("k", fingerprint="fp1")
+        fresh = CppCallGraphExtractor(cache_dir=tmp_path)
+        assert fresh.load_cache("k", expect_fingerprint="fp2") is False
+        assert fresh.function_locations == {}
+
+    def test_matching_fingerprint_loads(self, extractor, tmp_path):
+        self._seeded(extractor).save_cache("k", fingerprint="fp1")
+        fresh = CppCallGraphExtractor(cache_dir=tmp_path)
+        assert fresh.load_cache("k", expect_fingerprint="fp1") is True
+        assert "f" in fresh.function_locations
+
+    def test_legacy_cache_without_fingerprint_rejected(self, extractor, tmp_path):
+        self._seeded(extractor).save_cache("k")
+        fresh = CppCallGraphExtractor(cache_dir=tmp_path)
+        assert fresh.load_cache("k", expect_fingerprint="fp1") is False
+
+    def test_no_expectation_loads_anything(self, extractor, tmp_path):
+        self._seeded(extractor).save_cache("k", fingerprint="fp1")
+        fresh = CppCallGraphExtractor(cache_dir=tmp_path)
+        assert fresh.load_cache("k") is True
+
+
+class TestLevenshteinCap:
+    def test_long_names_do_not_cross_match_unrelated_ops(self, extractor):
+        _seed(
+            extractor,
+            {
+                "/nll.cpp": {
+                    "callees": {},
+                    "callers": {"nll_loss_backward_out_cpu_template": ["nll_caller"]},
+                    "function_locations": {
+                        "nll_loss_backward_out_cpu_template": ("/nll.cpp", 1)
+                    },
+                },
+            },
+        )
+        # 38-char query: old rule allowed 12 edits, matching nll_loss_*.
+        matches = extractor.match_functions(
+            "avg_pool2d_backward_out_cuda_template", fuzzy=True
+        )
+        assert matches == []
+
+    def test_small_typos_still_match(self, extractor):
+        _seed(
+            extractor,
+            {
+                "/s.cpp": {
+                    "callees": {},
+                    "callers": {},
+                    "function_locations": {"softmax_kernel": ("/s.cpp", 1)},
+                },
+            },
+        )
+        assert extractor.match_functions("softmax_kernal", fuzzy=True) == [
+            "softmax_kernel"
+        ]

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -5,6 +5,7 @@ from torchtalk.formatting import (
     Markdown,
     coverage_note,
     create_formatter,
+    relative_path,
     set_formatter_mode,
 )
 
@@ -93,11 +94,11 @@ class TestFormatterFactory:
 
 
 class TestCoverageNote:
+    def test_none_extractor_returns_empty(self):
+        assert coverage_note(None) == ""
+
     def test_empty_coverage_returns_empty(self):
         assert coverage_note(_FakeExtractor({})) == ""
-
-    def test_all_zero_returns_empty(self):
-        assert coverage_note(_FakeExtractor({"ok": 0, "filtered": 0})) == ""
 
     def test_ok_only_omits_unindexed(self):
         assert (
@@ -107,8 +108,20 @@ class TestCoverageNote:
 
     def test_unsupported_language_appears(self):
         note = coverage_note(_FakeExtractor({"ok": 1216, "unsupported_language": 5147}))
-        assert "unindexed: 5,147 CUDA/.mm/.cc" in note
+        assert "unindexed: 5,147 unsupported" in note
         assert "1,216 of 6,363" in note
+
+    def test_cu_cc_composition_appears(self):
+        cov = {
+            "ok": 1200,
+            "unsupported_language": 400,
+            "parse_failed": 60,
+            "cu_unindexed": 397,
+            "cc_unindexed": 50,
+        }
+        note = coverage_note(_FakeExtractor(cov))
+        assert "(incl. 397 .cu, 50 .cc)" in note
+        assert "1,200 of 1,660" in note
 
     def test_parse_failed_appears(self):
         note = coverage_note(_FakeExtractor({"ok": 1200, "parse_failed": 260}))
@@ -123,9 +136,23 @@ class TestCoverageNote:
         }
         note = coverage_note(_FakeExtractor(cov))
         assert "1,216 of 7,883" in note
-        assert "5,147 CUDA/.mm/.cc" in note
+        assert "5,147 unsupported" in note
         assert "200 parse-failed" in note
 
     def test_filtered_counted_in_total(self):
         note = coverage_note(_FakeExtractor({"ok": 10, "filtered": 5}))
         assert "10 of 15" in note
+
+
+class TestRelativePath:
+    def test_strips_base_prefix(self):
+        assert relative_path("/src/pytorch/aten/x.cpp", "/src/pytorch") == "aten/x.cpp"
+
+    def test_strips_pytorch_fallback_without_base(self):
+        assert relative_path("pytorch/aten/x.cpp") == "aten/x.cpp"
+
+    def test_strips_checkout_name_for_other_repos(self):
+        assert relative_path("vllm/csrc/ops.cpp", "/scratch/vllm") == "csrc/ops.cpp"
+
+    def test_unrelated_path_unchanged(self):
+        assert relative_path("other/x.cpp", "/src/pytorch") == "other/x.cpp"

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -151,8 +151,5 @@ class TestRelativePath:
     def test_strips_pytorch_fallback_without_base(self):
         assert relative_path("pytorch/aten/x.cpp") == "aten/x.cpp"
 
-    def test_strips_checkout_name_for_other_repos(self):
-        assert relative_path("vllm/csrc/ops.cpp", "/scratch/vllm") == "csrc/ops.cpp"
-
     def test_unrelated_path_unchanged(self):
         assert relative_path("other/x.cpp", "/src/pytorch") == "other/x.cpp"

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -40,14 +40,28 @@ class TestMaxDepth:
 
 
 class _FakeExtractor:
-    def __init__(self, edges: dict[str, list[dict]], fuzzy_only: set[str]):
+    def __init__(
+        self,
+        edges: dict[str, list[dict]],
+        fuzzy_only: set[str] | None = None,
+        coverage: dict[str, int] | None = None,
+        matches: dict[str, list[str]] | None = None,
+    ):
         self._edges = edges
-        self._fuzzy_only = fuzzy_only
+        self._fuzzy_only = fuzzy_only or set()
+        self._coverage = coverage or {}
+        self._matches = matches or {}
 
     def get_callers(self, name: str, fuzzy: bool = True) -> list[dict]:
         if name in self._fuzzy_only and not fuzzy:
             return []
         return self._edges.get(name, [])
+
+    def coverage_summary(self) -> dict[str, int]:
+        return self._coverage
+
+    def match_functions(self, name: str, fuzzy: bool = True) -> list[str]:
+        return self._matches.get(name, [name])
 
 
 @pytest.fixture
@@ -213,3 +227,189 @@ class TestImpactDepthClamp:
         out = asyncio.run(_do_impact("a", depth=10, fuzzy_all_levels=True))
         assert "`b`" in out and "`c`" in out and "`d`" in out
         assert "`e`" not in out and "`f`" not in out
+
+
+class TestCalledByCudaGap:
+    """_do_called_by must disclose unindexed .cu TUs instead of a confident
+    empty/narrow answer."""
+
+    def _setup(self, monkeypatch, edges, coverage):
+        indexer._state.cpp_extractor = _FakeExtractor(edges, coverage=coverage)
+        monkeypatch.setattr(graph_mod, "_cpp_status", lambda: "")
+        monkeypatch.setattr(graph_mod, "coverage_note", lambda _: "", raising=False)
+
+    def test_empty_result_mentions_cuda_gap(self, reset_extractor, monkeypatch):
+        self._setup(monkeypatch, {}, {"cu_unindexed": 397})
+        out = asyncio.run(graph_mod._do_called_by("GeluCUDAKernelImpl"))
+        assert "No inbound callers" in out
+        assert "397 .cu TUs unindexed" in out
+        assert "CUDA callers unknown" in out
+
+    def test_cuda_adjacent_result_mentions_gap(self, reset_extractor, monkeypatch):
+        edges = {
+            "gelu_out": [
+                {
+                    "caller": "GeluKernelImpl",
+                    "caller_file": "/src/aten/native/cuda/Gelu.cu",
+                    "caller_line": 5,
+                }
+            ]
+        }
+        self._setup(monkeypatch, edges, {"cu_unindexed": 10})
+        out = asyncio.run(graph_mod._do_called_by("gelu_out"))
+        assert "GeluKernelImpl" in out
+        assert "10 .cu TUs unindexed" in out
+
+    def test_cuda_named_query_mentions_gap(self, reset_extractor, monkeypatch):
+        edges = {
+            "launch_cuda_gemm": [
+                {"caller": "gemm_entry", "caller_file": "/a.cpp", "caller_line": 1}
+            ]
+        }
+        self._setup(monkeypatch, edges, {"cu_unindexed": 3})
+        out = asyncio.run(graph_mod._do_called_by("launch_cuda_gemm"))
+        assert "3 .cu TUs unindexed" in out
+
+    def test_non_cuda_result_omits_gap(self, reset_extractor, monkeypatch):
+        edges = {"foo": [{"caller": "bar", "caller_file": "/a.cpp", "caller_line": 1}]}
+        self._setup(monkeypatch, edges, {"cu_unindexed": 10})
+        out = asyncio.run(graph_mod._do_called_by("foo"))
+        assert "CUDA callers unknown" not in out
+
+    def test_no_gap_no_note(self, reset_extractor, monkeypatch):
+        self._setup(monkeypatch, {}, {})
+        out = asyncio.run(graph_mod._do_called_by("GeluCUDAKernelImpl"))
+        assert "CUDA callers unknown" not in out
+
+
+class TestFuzzyResolutionDisclosure:
+    """Fuzzy graph lookups disclose resolution instead of merging neighborhoods."""
+
+    def _setup(self, monkeypatch, ext):
+        indexer._state.cpp_extractor = ext
+        monkeypatch.setattr(graph_mod, "_cpp_status", lambda: "")
+        monkeypatch.setattr(graph_mod, "coverage_note", lambda _: "", raising=False)
+
+    def test_fuzzy_resolution_disclosed(self, reset_extractor, monkeypatch):
+        edges = {
+            "at::native::gemm": [
+                {"caller": "linear_fwd", "caller_file": "/a.cpp", "caller_line": 1}
+            ]
+        }
+        matches = {"gemm": ["at::native::gemm", "at::cpublas::gemm"]}
+        self._setup(monkeypatch, _FakeExtractor(edges, matches=matches))
+
+        out = asyncio.run(graph_mod._do_called_by("gemm"))
+        assert "Resolved 'gemm' → 'at::native::gemm' (fuzzy)" in out
+        assert "at::cpublas::gemm" in out
+        assert "linear_fwd" in out
+
+    def test_multiple_matches_not_merged(self, reset_extractor, monkeypatch):
+        edges = {
+            "at::native::gemm": [
+                {"caller": "linear_fwd", "caller_file": "/a.cpp", "caller_line": 1}
+            ],
+            "at::cpublas::gemm": [
+                {"caller": "blas_entry", "caller_file": "/b.cpp", "caller_line": 2}
+            ],
+        }
+        matches = {"gemm": ["at::native::gemm", "at::cpublas::gemm"]}
+        self._setup(monkeypatch, _FakeExtractor(edges, matches=matches))
+
+        out = asyncio.run(graph_mod._do_called_by("gemm"))
+        assert "linear_fwd" in out
+        assert "blas_entry" not in out
+
+    def test_exact_match_has_no_disclosure(self, reset_extractor, monkeypatch):
+        edges = {
+            "addmm": [{"caller": "linear", "caller_file": "/a.cpp", "caller_line": 1}]
+        }
+        self._setup(monkeypatch, _FakeExtractor(edges))
+
+        out = asyncio.run(graph_mod._do_called_by("addmm"))
+        assert "Resolved" not in out
+        assert "linear" in out
+
+    def test_impact_discloses_resolution(self, reset_extractor, monkeypatch):
+        edges = {
+            "at::native::gemm": [
+                {"caller": "linear_fwd", "caller_file": "/a.cpp", "caller_line": 1}
+            ]
+        }
+        matches = {"gemm": ["at::native::gemm"]}
+        self._setup(monkeypatch, _FakeExtractor(edges, matches=matches))
+
+        out = asyncio.run(_do_impact("gemm", depth=1))
+        assert "Resolved 'gemm' → 'at::native::gemm' (fuzzy)" in out
+        assert "linear_fwd" in out
+
+
+class TestResolutionSkipsEmptyCandidates:
+    def test_first_candidate_with_callers_wins(self, reset_extractor, monkeypatch):
+        # rank-1 candidate has no callers; rank-2 holds the real answer
+        edges = {
+            "std::at::addmm": [
+                {
+                    "caller": "at::native::linear",
+                    "caller_file": "/l.cpp",
+                    "caller_line": 9,
+                }
+            ]
+        }
+        matches = {"addmm": ["at::addmm", "std::at::addmm"]}
+        indexer._state.cpp_extractor = _FakeExtractor(edges, matches=matches)
+        monkeypatch.setattr(graph_mod, "_cpp_status", lambda: "")
+        monkeypatch.setattr(graph_mod, "coverage_note", lambda _: "", raising=False)
+
+        out = asyncio.run(graph_mod._do_called_by("addmm"))
+        assert "Resolved 'addmm' → 'std::at::addmm' (fuzzy)" in out
+        assert "at::native::linear" in out
+        assert "`at::addmm`" in out  # listed as another match, not merged
+
+    def test_empty_result_still_disclosed(self, reset_extractor, monkeypatch):
+        matches = {"addmm": ["at::addmm", "std::at::addmm"]}
+        indexer._state.cpp_extractor = _FakeExtractor({}, matches=matches)
+        monkeypatch.setattr(graph_mod, "_cpp_status", lambda: "")
+        monkeypatch.setattr(graph_mod, "coverage_note", lambda _: "", raising=False)
+
+        out = asyncio.run(graph_mod._do_called_by("addmm"))
+        assert "No inbound callers" in out
+        assert "Resolved 'addmm'" in out
+        assert "std::at::addmm" in out
+
+
+class TestImpactIncludesSeed:
+    def test_walk_python_includes_seed_edges(self, reset_extractor, monkeypatch):
+        # Seed has a Python source caller but zero C++ callers at depth>0.
+        edges = {
+            "at::native::gelu": [
+                {"caller": "gelu_meta", "caller_file": "/m.cpp", "caller_line": 1}
+            ]
+        }
+        indexer._state.cpp_extractor = _FakeExtractor(edges)
+        monkeypatch.setattr(
+            indexer._state,
+            "py_to_cpp_edges",
+            {
+                "aten::gelu": [
+                    {
+                        "caller_qualname": "torch.nn.GELU.forward",
+                        "file": "/g.py",
+                        "line": 7,
+                    }
+                ]
+            },
+        )
+        monkeypatch.setattr(
+            indexer._state,
+            "by_cpp_name",
+            {"gelu": [{"python_name": "aten.gelu", "cpp_name": "gelu"}]},
+        )
+        monkeypatch.setattr(graph_mod, "_cpp_status", lambda: "")
+        monkeypatch.setattr(graph_mod, "coverage_note", lambda _: "", raising=False)
+
+        out = asyncio.run(
+            _do_impact("at::native::gelu", depth=1, walk_python=True, focus="full")
+        )
+        assert "Python Source Callers" in out
+        assert "torch.nn.GELU.forward" in out

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -2,6 +2,7 @@
 
 import ast
 import json
+import subprocess
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -34,12 +35,6 @@ from torchtalk.indexer import (
 
 
 class TestServerState:
-    def test_default_empty(self):
-        state = ServerState()
-        assert state.bindings == []
-        assert state.native_functions == {}
-        assert state.pytorch_source is None
-
     def test_build_indexes(self):
         state = ServerState()
         state.bindings = [
@@ -143,10 +138,13 @@ class TestImplsFromExtractor:
     @pytest.fixture(autouse=True)
     def reset_state(self):
         prior = indexer._state.cpp_extractor
+        prior_src = indexer._state.pytorch_source
+        indexer._state.pytorch_source = None
         try:
             yield
         finally:
             indexer._state.cpp_extractor = prior
+            indexer._state.pytorch_source = prior_src
 
     def _fake_extractor(self, locations: dict) -> SimpleNamespace:
         return SimpleNamespace(function_locations=locations)
@@ -189,6 +187,17 @@ class TestImplsFromExtractor:
             {"at::native::add": ("/Add.cpp", 1)}
         )
         assert _impls_from_extractor("nope") == []
+
+    def test_out_of_tree_matches_filtered(self):
+        indexer._state.pytorch_source = "/src/pytorch"
+        indexer._state.cpp_extractor = self._fake_extractor(
+            {
+                "at::native::t": ("/src/pytorch/aten/T.cpp", 10),
+                "std::uniform::t": ("/usr/include/c++/11/bits/random.h", 3768),
+            }
+        )
+        result = _impls_from_extractor("t")
+        assert [r["file_path"] for r in result] == ["/src/pytorch/aten/T.cpp"]
 
 
 class TestBuildPyToCppEdges:
@@ -617,3 +626,114 @@ class TestCollectTestAttrHits:
         code = "def test_copy(self):\n    t.copy_(other)\n"
         index = self._walk(code, {"copy_"})
         assert index["copy_"][0]["receiver_type"] is None
+
+
+class TestCacheInvalidationByGitState:
+    """_cache_valid must reject caches after commits/pulls and dirty edits."""
+
+    def _commit(self, cwd, msg):
+        subprocess.run(
+            ["git", "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qam", msg],
+            cwd=cwd,
+            check=True,
+        )
+
+    def _repo_with_cache(self, tmp_path):
+        src = tmp_path / "src"
+        src.mkdir()
+        subprocess.run(["git", "init", "-q"], cwd=src, check=True)
+        (src / "kernel.cpp").write_text("int f() { return 1; }")
+        subprocess.run(["git", "add", "kernel.cpp"], cwd=src, check=True)
+        self._commit(src, "init")
+
+        cache = tmp_path / "bindings.json"
+        cache.write_text(
+            json.dumps(
+                {
+                    "bindings": [],
+                    "metadata": indexer._cache_metadata(str(src)),
+                }
+            )
+        )
+        return src, cache
+
+    def test_valid_across_noop_restart(self, tmp_path):
+        src, cache = self._repo_with_cache(tmp_path)
+        assert indexer._cache_valid(cache, str(src)) is True
+        assert indexer._cache_valid(cache, str(src)) is True
+
+    def test_invalidated_by_new_commit(self, tmp_path):
+        src, cache = self._repo_with_cache(tmp_path)
+        (src / "kernel.cpp").write_text("int f() { return 2; }")
+        self._commit(src, "edit")
+        assert indexer._cache_valid(cache, str(src)) is False
+
+    def test_invalidated_by_dirty_indexed_file(self, tmp_path):
+        src, cache = self._repo_with_cache(tmp_path)
+        (src / "kernel.cpp").write_text("int f() { return 3; }")
+        assert indexer._cache_valid(cache, str(src)) is False
+
+
+class TestUpdateIndexMetadata:
+    """update_index must write metadata that survives _cache_valid on restart."""
+
+    def _run_noop_update(self, tmp_path, monkeypatch):
+        src = tmp_path / "src"
+        src.mkdir()
+        cache = tmp_path / "cache"
+        snap_dir = cache / "snapshots" / "baseline"
+        snap_dir.mkdir(parents=True)
+        (snap_dir / "bindings.json").write_text(json.dumps({"bindings": []}))
+        (snap_dir / "manifest.json").write_text(
+            json.dumps(
+                {
+                    "name": "baseline",
+                    "created": "2026-01-01T00:00:00+00:00",
+                    "pytorch_source": str(src),
+                    "source_fingerprint": "deadbeef",
+                    "git_commit": "abc1234",
+                    "bindings_size": 0,
+                    "bindings_sha256": "x",
+                    "content_fingerprint": None,
+                    "schema_version": 2,
+                }
+            )
+        )
+
+        cache_file = cache / "bindings.json"
+        monkeypatch.setattr(snapshots, "SNAPSHOTS_DIR", cache / "snapshots")
+        monkeypatch.setattr(indexer, "CACHE_DIR", cache)
+        monkeypatch.setattr(indexer, "_cache_path", lambda _s: cache_file)
+        monkeypatch.setattr(indexer, "_source_fingerprint", lambda _s: "fp")
+
+        def fake_diff(cmd, **kwargs):
+            class R:
+                stdout = ""
+
+            return R()
+
+        monkeypatch.setattr(subprocess, "run", fake_diff)
+        indexer.update_index(str(src), since="baseline")
+        return cache_file, src
+
+    def test_updated_cache_survives_restart_validation(self, tmp_path, monkeypatch):
+        cache_file, src = self._run_noop_update(tmp_path, monkeypatch)
+        assert indexer._cache_valid(cache_file, str(src)) is True
+
+    def test_update_writes_all_build_metadata_keys(self, tmp_path, monkeypatch):
+        cache_file, src = self._run_noop_update(tmp_path, monkeypatch)
+        written = json.loads(cache_file.read_text())["metadata"]
+        assert set(indexer._cache_metadata(str(src))) <= set(written)
+
+
+class TestFuzzyFindDeterminism:
+    def test_suffix_match_prefers_shortest_not_dict_order(self):
+        data = {
+            "at::really_long_namespace::relu": [{"name": "long"}],
+            "at::x::relu": [{"name": "short"}],
+        }
+        assert _fuzzy_find("relu", data)[0]["name"] == "short"
+
+    def test_suffix_tie_breaks_lexicographically(self):
+        data = {"zz_relu": [{"name": "z"}], "aa_relu": [{"name": "a"}]}
+        assert _fuzzy_find("relu", data)[0]["name"] == "a"

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -1,0 +1,60 @@
+"""Tests for the modules list tool grouping."""
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from torchtalk import indexer
+from torchtalk.tools.modules import _do_list_modules
+
+
+def _cls(name, qualified):
+    return SimpleNamespace(name=name, qualified_name=qualified)
+
+
+@pytest.fixture
+def module_state():
+    s = indexer._state
+    saved = (s.py_classes, s.nn_modules, s.bindings, s.native_functions)
+    s.bindings = [{"python_name": "x"}]
+    s.native_functions = {}
+    s.nn_modules = [
+        _cls("Linear", "torch.nn.Linear"),
+        _cls("MSELoss", "torch.nn.MSELoss"),
+        _cls("ModuleList", "torch.nn.ModuleList"),
+        _cls("ModuleDict", "torch.nn.ModuleDict"),
+    ]
+    s.py_classes = {
+        "SGD": [_cls("SGD", "torch.optim.SGD")],
+        "ArgMappingException": [
+            _cls("ArgMappingException", "torch.distributed.optim.ArgMappingException")
+        ],
+        **{
+            f"Opt{i:02d}": [_cls(f"Opt{i:02d}", f"torch.optim.Opt{i:02d}")]
+            for i in range(22)
+        },
+    }
+    try:
+        yield s
+    finally:
+        (s.py_classes, s.nn_modules, s.bindings, s.native_functions) = saved
+
+
+class TestNnGrouping:
+    def test_sections_partition_no_double_count(self, module_state):
+        out = asyncio.run(_do_list_modules("nn"))
+        assert "Found 4 nn.Module subclasses" in out
+        assert "Layers (1)" in out
+        assert "Loss Functions (1)" in out
+        assert "Containers (2)" in out
+
+
+class TestOptimListing:
+    def test_truncation_footer_present(self, module_state):
+        out = asyncio.run(_do_list_modules("optim"))
+        assert "more.*" in out or "more." in out
+
+    def test_non_optimizers_excluded(self, module_state):
+        out = asyncio.run(_do_list_modules("optim"))
+        assert "ArgMappingException" not in out

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -1,0 +1,106 @@
+"""Tests for operator trace/search tools."""
+
+import asyncio
+
+import pytest
+
+from torchtalk import indexer
+from torchtalk.tools.ops import _do_cuda_kernels, trace
+
+
+@pytest.fixture
+def state_without_call_graph():
+    """Loaded index with no C++ call graph (background build / no libclang)."""
+    s = indexer._state
+    saved = (
+        s.native_functions,
+        s.bindings,
+        s.cuda_kernels,
+        s.cpp_extractor,
+        s.pytorch_source,
+    )
+    s.native_functions = {
+        "add": {
+            "name": "add",
+            "base_name": "add",
+            "signature": "add(Tensor self, Tensor other) -> Tensor",
+            "dispatch": {"CPU": "add_cpu"},
+            "variants": "function",
+            "python_module": "",
+            "structured": False,
+            "structured_delegate": None,
+            "tags": [],
+        }
+    }
+    s.bindings = []
+    s.cuda_kernels = [
+        {"name": "add_kernel", "file_path": "/src/a.cu", "line_number": 3}
+    ]
+    s.cpp_extractor = None
+    s.pytorch_source = "/src"
+    indexer._build_indexes(s)
+    try:
+        yield s
+    finally:
+        (
+            s.native_functions,
+            s.bindings,
+            s.cuda_kernels,
+            s.cpp_extractor,
+            s.pytorch_source,
+        ) = saved
+        indexer._build_indexes(s)
+
+
+class TestTraceWithoutCallGraph:
+    @pytest.mark.parametrize("focus", ["full", "yaml", "dispatch"])
+    def test_trace_does_not_crash(self, state_without_call_graph, focus):
+        out = asyncio.run(trace("add", focus=focus))
+        assert "add" in out
+
+    def test_trace_unknown_function(self, state_without_call_graph):
+        out = asyncio.run(trace("definitely_not_an_op_xyz"))
+        assert isinstance(out, str)
+
+
+class TestCudaKernelsWithoutCallGraph:
+    def test_kernel_search_does_not_crash(self, state_without_call_graph):
+        out = asyncio.run(_do_cuda_kernels("add"))
+        assert "add_kernel" in out
+
+
+class TestTraceImplDedupe:
+    def test_duplicates_deduped_before_slice(self, state_without_call_graph):
+        s = state_without_call_graph
+        dup = {"function_name": "add_cpu", "file_path": "/a.cpp", "line_number": 1}
+        uniq = [
+            {"function_name": f"add_v{i}", "file_path": "/b.cpp", "line_number": i}
+            for i in range(2)
+        ]
+        s.native_implementations = {"add": [dup] * 10 + uniq}
+        out = asyncio.run(trace("add"))
+        assert "add_v0" in out
+        assert "add_v1" in out
+
+
+class TestTraceFuzzyLabeling:
+    def test_fuzzy_dispatch_labeled_and_no_contradiction(
+        self, state_without_call_graph
+    ):
+        s = state_without_call_graph
+        s.native_functions = {}
+        s.bindings = [
+            {
+                "python_name": "hardswish",
+                "cpp_name": "qhardswish",
+                "dispatch_key": "QuantizedCPU",
+                "file_path": "/q.cpp",
+                "line_number": 5,
+            }
+        ]
+        from torchtalk import indexer
+
+        indexer._build_indexes(s)
+        out = asyncio.run(trace("hardswishh", focus="dispatch"))
+        assert "fuzzy match" in out
+        assert "Function Not Found" not in out

--- a/tests/test_tool_guards.py
+++ b/tests/test_tool_guards.py
@@ -1,0 +1,97 @@
+"""Regression tests: empty-input guards and limit clamps on tool entry points."""
+
+import asyncio
+
+import pytest
+
+from torchtalk import indexer
+from torchtalk.tools.graph import _do_called_by, _do_calls, _do_impact
+from torchtalk.tools.modules import _do_trace_module
+from torchtalk.tools.ops import _do_cuda_kernels, _do_search_bindings, trace
+from torchtalk.tools.tests import _do_find_similar_tests, _do_test_file_info
+
+
+@pytest.fixture
+def loaded_state():
+    s = indexer._state
+    saved = (
+        s.native_functions,
+        s.bindings,
+        s.cuda_kernels,
+        s.py_classes,
+        s.test_files,
+        s.cpp_extractor,
+        s.test_functions,
+        s.test_classes,
+        s.opinfo_registry,
+    )
+    s.native_functions = {"add": {"base_name": "add", "dispatch": {}}}
+    s.bindings = [
+        {
+            "python_name": "aten.add",
+            "cpp_name": "add",
+            "dispatch_key": "CPU",
+            "file_path": "/f.cpp",
+            "line_number": 1,
+        }
+    ]
+    s.cuda_kernels = [
+        {"name": "add_kernel", "file_path": "/a.cu", "line_number": 1},
+        {"name": "mul_kernel", "file_path": "/a.cu", "line_number": 9},
+    ]
+    s.py_classes = {"Linear": [{"name": "Linear"}]}
+    s.test_files = {"test/test_x.py": {"path": "test/test_x.py"}}
+    s.cpp_extractor = None
+    indexer._build_indexes(s)
+    try:
+        yield s
+    finally:
+        (
+            s.native_functions,
+            s.bindings,
+            s.cuda_kernels,
+            s.py_classes,
+            s.test_files,
+            s.cpp_extractor,
+            s.test_functions,
+            s.test_classes,
+            s.opinfo_registry,
+        ) = saved
+        indexer._build_indexes(s)
+
+
+class TestEmptyInputGuards:
+    def test_trace_empty(self, loaded_state):
+        assert "Provide a function name" in asyncio.run(trace(""))
+
+    def test_search_empty(self, loaded_state):
+        assert "Provide a query" in asyncio.run(_do_search_bindings("  "))
+
+    def test_graph_entry_points_empty(self, loaded_state):
+        for fn in (_do_calls, _do_called_by, _do_impact):
+            assert "Provide a function name" in asyncio.run(fn(""))
+
+    def test_modules_trace_empty(self, loaded_state):
+        assert "Provide a module" in asyncio.run(_do_trace_module(" "))
+
+    def test_tests_file_info_empty(self, loaded_state):
+        assert "Provide a test file name" in asyncio.run(_do_test_file_info(""))
+
+
+class TestLimitClamps:
+    def test_search_negative_limit(self, loaded_state):
+        out = asyncio.run(_do_search_bindings("add", limit=-1))
+        assert "Showing -1" not in out
+        assert "aten.add" in out
+
+    def test_kernels_zero_limit(self, loaded_state):
+        out = asyncio.run(_do_cuda_kernels("kernel", limit=0))
+        assert "Showing 0" not in out
+        assert "add_kernel" in out
+
+    def test_find_tests_negative_limit(self, loaded_state):
+        loaded_state.test_functions = {}
+        loaded_state.test_classes = {}
+        loaded_state.opinfo_registry = {}
+        out = asyncio.run(_do_find_similar_tests("add", limit=-5))
+        assert "and -" not in out

--- a/tests/test_word_match.py
+++ b/tests/test_word_match.py
@@ -35,3 +35,15 @@ class TestWordMatch:
 
     def test_no_match(self):
         assert not _word_match("matmul", "softmax")
+
+
+class TestLaterOccurrences:
+    def test_boundary_hit_after_failed_first_occurrence(self):
+        # first "add" is inside "padding" (fails), second is word-bounded
+        assert _word_match("add", "test_padding_add") is True
+
+    def test_all_occurrences_embedded_still_rejects(self):
+        assert _word_match("add", "test_padding_paddle") is False
+
+    def test_repeated_embedded_then_bounded(self):
+        assert _word_match("norm", "test_normalize_layer_norm") is True


### PR DESCRIPTION
Fixes a batch of correctness bugs found in an audit of the indexer, call graph, and MCP tools. 

### Correctness
- Cache invalidation now tracks git state (commit sha + dirty diff)
- Removed fabricated pybind method bindings (def-chain bounds) 
- Incremental `index update` no longer accretes stale edges from header-defined functions, and updated caches survive server restarts
- `trace`/`search` no longer crash while the C++ call graph is building or missing
- Binding line numbers render in `trace`/`search` (key mismatch), and snapshot diffs detect line moves

### Reliability
- Fuzzy matching is deterministic, capped, and disclosed ("Resolved 'x' → 'at::native::x' (fuzzy)") instead of silently merging substring matches
- Word-boundary test search matches all occurrences, not just the first.