### PR TITLE
[Feature] Add repository harness

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -22,7 +22,11 @@
   "mcpServers": {
     "torchtalk": {
       "command": "torchtalk",
-      "args": ["mcp-serve"],
+      "args": [
+        "mcp-serve",
+        "--harness",
+        "pytorch"
+      ],
       "env": {
         "PYTORCH_SOURCE": "${PYTORCH_SOURCE:-}"
       }

--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "torchtalk": {
       "command": "torchtalk",
-      "args": ["mcp-serve"],
+      "args": ["mcp-serve", "--harness", "pytorch"],
       "env": {
         "PYTORCH_SOURCE": "${PYTORCH_SOURCE:-}"
       }

--- a/scripts/plugin-setup.sh
+++ b/scripts/plugin-setup.sh
@@ -18,8 +18,9 @@ if ! command -v torchtalk >/dev/null 2>&1; then
     fi
 fi
 
-# Nudge if no PyTorch source resolves, matching config.resolve_pytorch_source:
-# PYTORCH_SOURCE, then PYTORCH_PATH (each must exist), then the config file.
+# Nudge if no source resolves, matching config.resolve_source: PYTORCH_SOURCE,
+# PYTORCH_PATH, or any TORCHTALK_SOURCE_* var (each must exist), then the
+# config file's [sources] table or legacy pytorch_source key.
 config_file="${XDG_CONFIG_HOME:-${HOME}/.config}/torchtalk/config.toml"
 source_configured=false
 
@@ -27,13 +28,16 @@ if [[ -n "${PYTORCH_SOURCE:-}" && -d "${PYTORCH_SOURCE}" ]]; then
     source_configured=true
 elif [[ -n "${PYTORCH_PATH:-}" && -d "${PYTORCH_PATH}" ]]; then
     source_configured=true
-elif [[ -f "${config_file}" ]] && grep -q "pytorch_source" "${config_file}" 2>/dev/null; then
+elif compgen -A variable | grep -q "^TORCHTALK_SOURCE_"; then
+    source_configured=true
+elif [[ -f "${config_file}" ]] \
+    && grep -qE "pytorch_source|^\[sources\]" "${config_file}" 2>/dev/null; then
     source_configured=true
 fi
 
 if [[ "${source_configured}" == false ]]; then
-    echo "TorchTalk: no PyTorch source configured. Set PYTORCH_SOURCE or run" \
-         "'torchtalk init --pytorch-source <path>' to enable cross-language" \
+    echo "TorchTalk: no source configured. Set PYTORCH_SOURCE or run" \
+         "'torchtalk init --source <path>' to enable cross-language" \
          "analysis of a PyTorch checkout (recommended)."
 fi
 

--- a/src/torchtalk/analysis/affected.py
+++ b/src/torchtalk/analysis/affected.py
@@ -11,6 +11,7 @@ import re
 from typing import Any
 
 from .cpp_call_graph import CppCallGraphExtractor
+from .helpers import word_match
 from .patterns import is_vendor_path
 
 _OVERLOAD_TAG_LITERALS = {"int", "default", "out", "self"}
@@ -99,6 +100,30 @@ def _strip_impl_suffix(name: str) -> list[str]:
         if name.endswith(suffix):
             return [name[: -len(suffix)]]
     return []
+
+
+_STRUCTURED_BACKEND_TAGS = ("_cpu", "_cuda", "_mps", "_meta", "_xpu")
+
+
+def _structured_impl_candidates(qualified: str) -> list[str]:
+    """`...::structured_avg_pool2d_backward_out_cuda::impl` → op-name stems.
+
+    Structured kernels live in generated `structured_<op>[_out]_<backend>`
+    classes; walking a kernel lands on their `::impl` member, whose bare name
+    is useless. Caller must verify candidates against native_functions.
+    """
+    seg = next((p for p in qualified.split("::") if p.startswith("structured_")), None)
+    if seg is None:
+        return []
+    stem = seg[len("structured_") :]
+    for tag in _STRUCTURED_BACKEND_TAGS:
+        if stem.endswith(tag):
+            stem = stem[: -len(tag)]
+            break
+    out = [stem]
+    if stem.endswith("_out"):
+        out.append(stem[: -len("_out")])
+    return out
 
 
 _PLATFORM_TAGS = ("CUDA", "CPU", "MPS")
@@ -304,13 +329,19 @@ def _bindings_for(
             base,
             *_strip_impl_suffix(bare),
             *_pascal_kernel_impl_candidates(bare),
+            *_structured_impl_candidates(fn),
         ]
-        for key in keys:
-            if (native_implementations and key in native_implementations) or (
-                native_functions and key in native_functions
-            ):
-                _tag_apis(api_sources, [key], "call_graph")
-                break
+        # Real YAML ops beat impl-symbol hits across ALL candidates:
+        # `cummax_out` is in native_implementations, but its stripped stem
+        # `cummax` is the actual op (and the OpInfo key).
+        hit = next(
+            (k for k in keys if native_functions and k in native_functions), None
+        ) or next(
+            (k for k in keys if native_implementations and k in native_implementations),
+            None,
+        )
+        if hit is not None:
+            _tag_apis(api_sources, [hit], "call_graph")
         else:
             # Fallback B: bare symbol is a CPU/CUDA kernel impl registered via
             # REGISTER_DISPATCH(stub, &kernel) — resolve via stub-to-op map.
@@ -353,10 +384,17 @@ def _tests_for_apis(
 
 
 def api_attr_variants(api: str) -> set[str]:
-    """API-name forms a test source might reference as an attribute access."""
+    """API-name forms a test source might reference as an attribute access.
+
+    Includes the nn-Module wrapper spelling (`avg_pool2d` ↔ `AvgPool2d`) —
+    tests often exercise an op only through its module class.
+    """
     base = api.rstrip("_")
     leaf = base.rsplit(".", 1)[-1] if "." in base else base
     variants = {api, base, leaf, leaf + "_"}
+    pascal = "".join(p.capitalize() for p in leaf.split("_") if p)
+    if pascal != leaf:
+        variants.add(pascal)
     return {v for v in variants if v}
 
 
@@ -400,6 +438,45 @@ def _tests_via_profiling(
     return by_file
 
 
+def _k_expr(ops) -> str:
+    """Pytest -k expression matching parametrized OpInfo test names."""
+    return " or ".join(sorted({op.replace(".", "_") for op in ops}))
+
+
+def _function_level_hits(
+    apis: set[str],
+    test_functions: dict[str, list[dict]],
+    selected_files: set[str],
+) -> dict[str, dict[str, list[str]]]:
+    """file → class → test functions word-matching an API (leaf len ≥ 4).
+
+    Refines already-selected files to `::Class::function` granularity; short
+    leaves are skipped so generic names never flood the join.
+    """
+    queries: set[str] = set()
+    for api in apis:
+        leaf = api.rstrip("_").rsplit(".", 1)[-1]
+        if len(leaf) >= 4:
+            queries.add(leaf.lower())
+    hits: dict[str, dict[str, list[str]]] = {}
+    if not queries:
+        return hits
+    for fname, locs in test_functions.items():
+        low = fname.lower()
+        if not any(word_match(q, low) for q in queries):
+            continue
+        for loc in locs:
+            file, cls = loc.get("file"), loc.get("class")
+            if file in selected_files and cls:
+                bucket = hits.setdefault(file, {}).setdefault(cls, [])
+                if fname not in bucket:
+                    bucket.append(fname)
+    for classes in hits.values():
+        for names in classes.values():
+            names.sort()
+    return hits
+
+
 def _tests_mentioning_apis(
     apis: set[str],
     test_attr_index: dict[str, list[dict]],
@@ -408,11 +485,12 @@ def _tests_mentioning_apis(
 ) -> tuple[dict[str, set[str]], set[str]]:
     """Map test file → classes whose `test_*` methods reference any of `apis`.
 
-    Drops an API's mention-only contribution entirely when it would exceed
-    `per_api_cap`. Generic names like `add` mention-match thousands of unrelated
-    tests; over-cap APIs are too low-specificity to be a reliable signal. Pass
-    `per_api_cap=None` to disable the cap. The class-name match path
-    (`_tests_for_apis`) is unaffected.
+    Drops an API's mention-only contribution entirely when its hits spread
+    across more than `per_api_cap` distinct files. Generic names like `add`
+    mention-match hundreds of unrelated files; over-cap APIs are too
+    low-specificity to be a reliable signal. Pass `per_api_cap=None` to
+    disable the cap. The class-name match path (`_tests_for_apis`) is
+    unaffected.
 
     Returns (by_file, contributing_apis) where contributing_apis is the subset
     of `apis` that actually placed a hit into `by_file` (post-cap).
@@ -429,7 +507,9 @@ def _tests_mentioning_apis(
                     continue
                 if cls := hit.get("class"):
                     api_hits.append((hit["file"], cls))
-        if per_api_cap is not None and len(api_hits) > per_api_cap:
+        # Specificity = spread, not frequency: `avg_pool2d` has 55 hits in 14
+        # files (keep); `add` has 2,864 across ~300 files (drop).
+        if per_api_cap is not None and len({p for p, _ in api_hits}) > per_api_cap:
             continue
         for path, cls in api_hits:
             by_file.setdefault(path, set()).add(cls)
@@ -457,6 +537,7 @@ def affected_tests(
     bindings_by_file: dict[str, list[dict]] | None = None,
     ops_by_file: dict[str, set[str]] | None = None,
     symbol_to_file: dict[str, str] | None = None,
+    test_functions: dict[str, list[dict]] | None = None,
     depth: int = 3,
     mention_cap: int | None = 50,
     cohort_cap: int = 15,
@@ -525,10 +606,34 @@ def affected_tests(
         _tag_apis(api_sources, mention_apis, "mention")
 
     # An API matches OpInfo directly OR via an `aliases=`/`aten_name=` link.
+    # Dotted registry keys (`torch.ops.aten.foo`) are reachable via their leaf.
+    # Only precise-tier APIs may trigger OpInfo expansion — fuzzy cohort noise
+    # (`max`/`min` binding artifacts) used to pull in the whole 48-file blanket.
     opinfo_keys: set[str] = set(opinfo_registry or {}) | set(opinfo_alias_map or {})
-    if opinfo_test_files and apis & opinfo_keys:
-        for path in opinfo_test_files:
-            by_file.setdefault(path, set())
+    opinfo_leaf: dict[str, str] = {}
+    for k in opinfo_keys:
+        if "." in k:
+            opinfo_leaf.setdefault(k.rsplit(".", 1)[-1], k)
+
+    precise_apis = {a for a, tags in api_sources.items() if tags & _PRECISE_TAGS}
+    matched_ops: dict[str, str] = {}
+    for api in precise_apis:
+        if api in opinfo_keys:
+            matched_ops[api] = api
+        elif api in opinfo_leaf:
+            matched_ops[api] = opinfo_leaf[api]
+
+    canonical = [
+        f
+        for f in ("test/test_ops.py", "test/test_meta.py", "test/test_decomp.py")
+        if f in (opinfo_test_files or set())
+    ]
+    opinfo_runs: list[dict[str, Any]] = []
+    if matched_ops and canonical:
+        # OpInfo-parametrized test names embed the op name — `-k` gives
+        # function-level precision instead of 48 whole-file runs.
+        opinfo_runs.append({"files": canonical, "k": _k_expr(matched_ops.values())})
+        _tag_apis(api_sources, matched_ops, "opinfo")
 
     # PyTorch CI's coverage-based map adds whole-file runs for tests that
     # touched the API's Python source file at runtime.
@@ -536,15 +641,22 @@ def affected_tests(
         for path in _tests_via_profiling(apis, python_profiling, test_files):
             by_file.setdefault(path, set())
 
-    # Catch-all: APIs resolved but no test file matched anywhere. Internal
-    # ops (`convolution_overrideable`, `_safe_softmax`) often have no dedicated
-    # test class and aren't in OpInfo, but they're exercised transitively from
-    # the catch-all `@ops(op_db)` test classes in test_ops.py / test_meta.py.
-    # Cost is low (parametrized tests skip non-matching ops).
-    if apis and not by_file and opinfo_test_files:
-        for path in opinfo_test_files:
-            by_file.setdefault(path, set())
-        _tag_apis(api_sources, apis, "opinfo_catchall")
+    # Catch-all, precise-gated and `-k`-bounded: internal ops with no dedicated
+    # test class are exercised transitively via `@ops(op_db)` in test_ops.py.
+    if precise_apis and not by_file and not opinfo_runs and canonical:
+        opinfo_runs.append({"files": canonical, "k": _k_expr(precise_apis)})
+        _tag_apis(api_sources, precise_apis, "opinfo_catchall")
+
+    # Derivatives-aware: `*_backward` inputs exercise gradcheck through the
+    # forward op's OpInfo entry (TestBwdGradients).
+    grad_file = "test/test_ops_gradients.py"
+    backward_fwd = {a for a, tags in api_sources.items() if "backward_alias" in tags}
+    if backward_fwd and grad_file in test_files:
+        opinfo_runs.append({"files": [grad_file], "k": _k_expr(backward_fwd)})
+
+    function_hits: dict[str, dict[str, list[str]]] = {}
+    if test_functions and by_file:
+        function_hits = _function_level_hits(precise_apis, test_functions, set(by_file))
 
     return {
         "input_functions": list(funcs),
@@ -564,6 +676,8 @@ def affected_tests(
             {"file": f, "included_classes": sorted(classes)}
             for f, classes in sorted(by_file.items())
         ],
+        "opinfo_runs": opinfo_runs,
+        "function_hits": function_hits,
     }
 
 

--- a/src/torchtalk/analysis/binding_detector.py
+++ b/src/torchtalk/analysis/binding_detector.py
@@ -164,6 +164,9 @@ class BindingDetector:
         self,
         macro_aliases: dict[str, str] | None = None,
         token_map: dict[str, str] | None = None,
+        search_dirs: tuple[str, ...] | None = None,
+        exclude_patterns: tuple[str, ...] | None = None,
+        registration_macros: tuple[str, ...] | None = None,
     ):
         from tree_sitter_language_pack import get_parser
 
@@ -171,6 +174,10 @@ class BindingDetector:
         self.cuda_parser = get_parser("cuda")  # If available, falls back to cpp
         self.macro_aliases = macro_aliases or {}
         self.token_map = token_map or {}
+        self.search_dirs = search_dirs or ()
+        # Empty tuples fall back to the PyTorch defaults in patterns.py.
+        self.exclude_patterns = exclude_patterns or ()
+        self.registration_macros = registration_macros or ()
         log.info("BindingDetector initialized with C++/CUDA support")
 
     def _preprocess(self, content: str) -> str:
@@ -660,14 +667,21 @@ class BindingDetector:
         return (node.text or b"").decode("utf-8", errors="replace")
 
     def detect_bindings_in_directory(self, directory: str) -> BindingGraph:
-        """Scan a directory for cross-language bindings."""
+        """Scan a directory (bounded by search_dirs when set) for bindings."""
         dir_path = Path(directory)
         combined_graph = BindingGraph()
 
+        if self.search_dirs:
+            roots = [dir_path / d for d in self.search_dirs if (dir_path / d).exists()]
+        else:
+            roots = [dir_path]
+
         extensions = ["*.cpp", "*.cc", "*.cxx", "*.cu", "*.cuh"]
-        files = []
-        for ext in extensions:
-            files.extend(dir_path.rglob(ext))
+        files: list[Path] = []
+        for root in roots:
+            for ext in extensions:
+                files.extend(root.rglob(ext))
+        files = list(dict.fromkeys(files))
 
         log.info(f"Scanning {len(files)} C++/CUDA files for bindings...")
 
@@ -676,16 +690,16 @@ class BindingDetector:
         for cpp_file in files:
             file_str = str(cpp_file)
 
-            # Apply exclusion patterns (from shared config)
-            if should_exclude(file_str):
+            # Apply exclusion patterns (manifest's, falling back to shared config)
+            if should_exclude(file_str, self.exclude_patterns):
                 skipped_excluded += 1
                 continue
 
             try:
                 content = cpp_file.read_text(encoding="utf-8", errors="replace")
 
-                # Fuzzy grep: check for binding-related patterns (from shared config)
-                if not has_binding_patterns(content):
+                # Fuzzy grep: check for binding-related patterns
+                if not has_binding_patterns(content, self.registration_macros):
                     skipped_no_patterns += 1
                     continue
 

--- a/src/torchtalk/analysis/binding_detector.py
+++ b/src/torchtalk/analysis/binding_detector.py
@@ -160,16 +160,33 @@ def _clean_impl_target(raw: str, op_name: str = "") -> str:
 class BindingDetector:
     """Detects pybind11, TORCH_LIBRARY, and CUDA binding patterns."""
 
-    def __init__(self):
+    def __init__(
+        self,
+        macro_aliases: dict[str, str] | None = None,
+        token_map: dict[str, str] | None = None,
+    ):
         from tree_sitter_language_pack import get_parser
 
         self.cpp_parser = get_parser("cpp")
         self.cuda_parser = get_parser("cuda")  # If available, falls back to cpp
+        self.macro_aliases = macro_aliases or {}
+        self.token_map = token_map or {}
         log.info("BindingDetector initialized with C++/CUDA support")
+
+    def _preprocess(self, content: str) -> str:
+        """Expand manifest macro aliases and tokens (line-count preserving)."""
+        for alias, canonical in self.macro_aliases.items():
+            content = re.sub(rf"\b{re.escape(alias)}\b", canonical, content)
+        for token, value in self.token_map.items():
+            content = re.sub(rf"\b{re.escape(token)}\b", value, content)
+        return content
 
     def detect_bindings(self, file_path: str, content: str) -> BindingGraph:
         """Parse a C++/CUDA file and extract bindings."""
         graph = BindingGraph()
+
+        if self.macro_aliases or self.token_map:
+            content = self._preprocess(content)
 
         is_cuda = file_path.endswith((".cu", ".cuh"))
         parser = self.cuda_parser if is_cuda else self.cpp_parser

--- a/src/torchtalk/analysis/cpp_call_graph.py
+++ b/src/torchtalk/analysis/cpp_call_graph.py
@@ -155,6 +155,7 @@ def _synthesize_missing_cu_entries(
     covered_files: set[str],
     template_args: list[str],
     cuda_env: dict,
+    exclude_patterns: tuple[str, ...] | None = None,
 ) -> list[tuple[str, list[str]]]:
     """Glob .cu files under include_dirs and synthesize entries for ones missing
     from compile_commands.json.
@@ -174,7 +175,7 @@ def _synthesize_missing_cu_entries(
             file_path = str(cu)
             if file_path in covered_files or file_path in seen:
                 continue
-            if should_exclude(file_path):
+            if should_exclude(file_path, exclude_patterns):
                 continue
             seen.add(file_path)
             extra.append(
@@ -308,13 +309,15 @@ class CppCallGraphExtractor:
         pytorch_source: str,
         num_workers: int | None = None,
         include_dirs: list[str] | None = None,
+        exclude_patterns: tuple[str, ...] | None = None,
     ) -> dict[str, Any]:
-        """Extract call graph from PyTorch using parallel processing.
+        """Extract call graph from source using parallel processing.
 
         Args:
-            pytorch_source: Path to PyTorch source directory
+            pytorch_source: Path to source directory
             num_workers: Number of parallel workers (default: 80% of CPU count)
-            include_dirs: Directory patterns to include
+            include_dirs: Directory patterns to include (default: PyTorch dirs)
+            exclude_patterns: Path exclusion patterns (default: PyTorch patterns)
         """
         source = Path(pytorch_source)
 
@@ -361,7 +364,7 @@ class CppCallGraphExtractor:
             if not should_include_dir(file_path, include_dirs):
                 self.tu_status[tu_rel] = "filtered"
                 continue
-            if should_exclude(file_path):
+            if should_exclude(file_path, exclude_patterns):
                 self.tu_status[tu_rel] = "filtered"
                 continue
 
@@ -374,7 +377,12 @@ class CppCallGraphExtractor:
 
         if cuda_env and template_raw_args is not None:
             synthesized = _synthesize_missing_cu_entries(
-                source, include_dirs, covered_files, template_raw_args, cuda_env
+                source,
+                include_dirs,
+                covered_files,
+                template_raw_args,
+                cuda_env,
+                exclude_patterns,
             )
             if synthesized:
                 log.info(

--- a/src/torchtalk/analysis/dispatch_stub_map.py
+++ b/src/torchtalk/analysis/dispatch_stub_map.py
@@ -18,6 +18,8 @@ import logging
 import re
 from pathlib import Path
 
+from .binding_detector import _CPP_CONTROL_KEYWORDS
+
 log = logging.getLogger(__name__)
 
 # Matches REGISTER_DISPATCH, REGISTER_AVX512, REGISTER_CUDA_DISPATCH,
@@ -60,7 +62,15 @@ def extract_kernel_impl_to_op(
     if not native_root.exists():
         return {}
 
+    impl_to_op: dict[str, str] = {}
+    for op_name, entry in native_functions.items():
+        for impl in entry.get("dispatch", {}).values():
+            if impl and impl != op_name:
+                impl_to_op.setdefault(impl, op_name)
+
     kernel_to_op: dict[str, str] = {}
+    unresolved: dict[str, list[str]] = {}
+    registers_by_file: dict[Path, list[str]] = {}
     for d in _SCAN_DIRS:
         sub = native_root / d
         if not sub.exists():
@@ -73,6 +83,91 @@ def extract_kernel_impl_to_op(
                     log.debug(f"Skipping {path}: {e}")
                     continue
                 for stub, kernel in _REGISTER_RE.findall(content):
+                    registers_by_file.setdefault(path, []).append(kernel)
                     if op := _stub_to_op(stub, nf_keys):
                         kernel_to_op[kernel] = op
+                    else:
+                        unresolved.setdefault(stub, []).append(kernel)
+    for stub, op in _stubs_via_call_sites(
+        native_root, set(unresolved), nf_keys, impl_to_op
+    ):
+        for kernel in unresolved[stub]:
+            kernel_to_op.setdefault(kernel, op)
+    _map_kernel_tu_helpers(registers_by_file, kernel_to_op)
     return kernel_to_op
+
+
+_FUNC_DEF_RE = re.compile(r"(\w+)\s*\([^)]*\)\s*(?:const\s*)?\{")
+_FILE_OP_CAP = 4
+
+
+def _map_kernel_tu_helpers(
+    registers_by_file: dict[Path, list[str]], kernel_to_op: dict[str, str]
+) -> None:
+    """Map helper functions in a kernel TU to the TU's registered op(s).
+
+    Kernel TUs are compiled as generated build/ copies the call graph
+    excludes, so helpers like `cpu_flash_attention` have no graph presence.
+    When a TU's registrations resolve to few ops, its other definitions
+    belong to those ops; `backward` helpers pair with `backward` ops.
+    """
+    for path, kernels in registers_by_file.items():
+        ops = {kernel_to_op[k] for k in kernels if k in kernel_to_op}
+        if not ops or len(ops) > _FILE_OP_CAP:
+            continue
+        fwd = sorted(o for o in ops if "backward" not in o)
+        bwd = sorted(o for o in ops if "backward" in o)
+        try:
+            content = path.read_text(errors="replace")
+        except OSError:
+            continue
+        for d in _FUNC_DEF_RE.finditer(content):
+            name = d.group(1)
+            if name in _CPP_CONTROL_KEYWORDS or name in kernel_to_op:
+                continue
+            pick = (bwd or fwd) if "backward" in name else (fwd or bwd)
+            kernel_to_op[name] = pick[0]
+
+
+def _stubs_via_call_sites(
+    native_root: Path,
+    stubs: set[str],
+    nf_keys: set[str],
+    impl_to_op: dict[str, str] | None = None,
+) -> list[tuple[str, str]]:
+    """Resolve name-mangled stubs to the YAML op whose body invokes them.
+
+    `_stub_to_op("flash_attention_kernel")` strips to `flash_attention`, which
+    is not an op — but the stub is called inside an op (or op dispatch-impl)
+    body in attention.cpp. Scan non-arch native sources for `stub(` call
+    sites; a direct native_functions enclosing name wins over one resolved
+    through the YAML dispatch table.
+    """
+    if not stubs:
+        return []
+    call_re = re.compile(
+        r"\b(" + "|".join(re.escape(s) for s in sorted(stubs)) + r")\s*\("
+    )
+    skip_prefixes = tuple(str(native_root / d) for d in _SCAN_DIRS)
+    direct: dict[str, str] = {}
+    via_impl: dict[str, str] = {}
+    for path in native_root.rglob("*.cpp"):
+        if str(path).startswith(skip_prefixes):
+            continue
+        try:
+            content = path.read_text(errors="replace")
+        except OSError:
+            continue
+        for m in call_re.finditer(content):
+            stub = m.group(1)
+            if stub in direct:
+                continue
+            enclosing = None
+            for d in _FUNC_DEF_RE.finditer(content, 0, m.start()):
+                if d.group(1) not in _CPP_CONTROL_KEYWORDS:
+                    enclosing = d.group(1)
+            if enclosing in nf_keys:
+                direct.setdefault(stub, enclosing)
+            elif impl_to_op and enclosing in impl_to_op:
+                via_impl.setdefault(stub, impl_to_op[enclosing])
+    return list({**via_impl, **direct}.items())

--- a/src/torchtalk/analysis/extractors.py
+++ b/src/torchtalk/analysis/extractors.py
@@ -1,0 +1,290 @@
+"""Config-driven registration extractors (Python AST) and qualname resolver.
+
+All extraction is driven by ConventionManifest fields — no repo-specific
+logic lives here. Honesty rule: records from string registries, string
+dispatchers, and the qualname-literal resolver carry kind="candidate" with
+the string evidence; only decorator and registration-call records (direct
+AST evidence) are kind="resolved". Candidates are never static call edges.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+from ..harness import ConventionManifest
+
+# Dotted identifier with at least one dot — the only literals the resolver
+# considers, so plain words never become candidate edges.
+_QUALNAME_RE = re.compile(r"^[A-Za-z_]\w*(?:\.[A-Za-z_]\w*)+$")
+
+
+def _dotted(node: ast.AST) -> str | None:
+    """Dotted source text of a Name/Attribute chain, else None."""
+    parts: list[str] = []
+    while isinstance(node, ast.Attribute):
+        parts.append(node.attr)
+        node = node.value
+    if isinstance(node, ast.Name):
+        parts.append(node.id)
+        return ".".join(reversed(parts))
+    return None
+
+
+def _matches(dotted: str | None, configured: str) -> bool:
+    """True when `dotted` is `configured` or ends with it at a dot boundary."""
+    if not dotted:
+        return False
+    return dotted == configured or dotted.endswith("." + configured)
+
+
+def _module_name(rel_path: str) -> str:
+    parts = Path(rel_path).with_suffix("").parts
+    if parts and parts[-1] == "__init__":
+        parts = parts[:-1]
+    return ".".join(parts)
+
+
+class _FileVisitor(ast.NodeVisitor):
+    """Single-pass collector for primitives 2-5 plus resolver raw material."""
+
+    def __init__(self, manifest: ConventionManifest, module: str, rel_path: str):
+        self.manifest = manifest
+        self.module = module
+        self.file = rel_path
+        self.scope: list[str] = []
+        self.records: list[dict] = []
+        self.candidate_edges: list[dict] = []
+        self.literals: list[dict] = []
+        self.qualnames: set[str] = {module}
+
+    def _here(self) -> str:
+        return ".".join([self.module, *self.scope]) if self.scope else self.module
+
+    def _enter(self, node) -> None:
+        qual = f"{self._here()}.{node.name}"
+        self.qualnames.add(qual)
+        self._check_decorators(node, qual)
+        self.scope.append(node.name)
+        self.generic_visit(node)
+        self.scope.pop()
+
+    def visit_ClassDef(self, node) -> None:
+        self._enter(node)
+
+    def visit_FunctionDef(self, node) -> None:
+        self._enter(node)
+
+    def visit_AsyncFunctionDef(self, node) -> None:
+        self._enter(node)
+
+    def _check_decorators(self, node, qual: str) -> None:
+        for dec in node.decorator_list:
+            call = dec if isinstance(dec, ast.Call) else None
+            name = _dotted(call.func) if call else _dotted(dec)
+            for configured, registry in self.manifest.decorator_registries.items():
+                if not _matches(name, configured):
+                    continue
+                for key in self._decorator_keys(call) or [node.name]:
+                    self.records.append(
+                        {
+                            "registry": registry,
+                            "key": key,
+                            "target": qual,
+                            "kind": "resolved",
+                            "via": "decorator",
+                            "file": self.file,
+                            "line": node.lineno,
+                        }
+                    )
+
+    def _decorator_keys(self, call: ast.Call | None) -> list[str]:
+        if call is None or not call.args:
+            return []
+        arg = call.args[0]
+        elts = arg.elts if isinstance(arg, (ast.List, ast.Tuple)) else [arg]
+        keys: list[str] = []
+        for e in elts:
+            if isinstance(e, ast.Constant) and isinstance(e.value, str):
+                keys.append(e.value)
+            elif d := _dotted(e):
+                keys.append(d)
+        return keys
+
+    def visit_Assign(self, node) -> None:
+        if not self.scope and isinstance(node.value, ast.Dict):
+            for target in node.targets:
+                if (
+                    isinstance(target, ast.Name)
+                    and target.id in self.manifest.string_registries
+                ):
+                    self._harvest_registry(target.id, node.value)
+        self.generic_visit(node)
+
+    def _harvest_registry(self, name: str, dict_node: ast.Dict) -> None:
+        for k, v in zip(dict_node.keys, dict_node.values, strict=True):
+            if not (isinstance(k, ast.Constant) and isinstance(k.value, str)):
+                continue
+            targets: list[str] = []
+            if isinstance(v, ast.Constant) and isinstance(v.value, str):
+                targets = [v.value]
+            elif isinstance(v, ast.Tuple) and len(v.elts) == 2:
+                mod, cls = v.elts
+                if all(
+                    isinstance(e, ast.Constant) and isinstance(e.value, str)
+                    for e in (mod, cls)
+                ):
+                    targets = [f"{mod.value}.{cls.value}"]
+            elif isinstance(v, ast.List):
+                targets = [
+                    f"{k.value}.{e.value}"
+                    for e in v.elts
+                    if isinstance(e, ast.Constant) and isinstance(e.value, str)
+                ]
+            for t in targets:
+                self.records.append(
+                    {
+                        "registry": name,
+                        "key": k.value,
+                        "target": t,
+                        "kind": "candidate",
+                        "via": "string_registry",
+                        "evidence": t,
+                        "file": self.file,
+                        "line": k.lineno,
+                    }
+                )
+
+    def visit_Call(self, node) -> None:
+        name = _dotted(node.func)
+        for cr in self.manifest.registration_calls:
+            if not _matches(name, cr.call):
+                continue
+            key = self._arg_value(node, cr.key_arg)
+            target = self._arg_value(node, cr.target_arg)
+            if key and target:
+                self.records.append(
+                    {
+                        "registry": cr.registry or cr.call,
+                        "key": key,
+                        "target": target,
+                        "kind": "resolved",
+                        "via": "call",
+                        "file": self.file,
+                        "line": node.lineno,
+                    }
+                )
+        for dispatcher, arg_spec in self.manifest.string_dispatchers.items():
+            if not _matches(name, dispatcher):
+                continue
+            method = self._arg_value(node, arg_spec, string_only=True)
+            if method:
+                self.candidate_edges.append(
+                    {
+                        "kind": "candidate",
+                        "via": "string_dispatch",
+                        "source": self._here(),
+                        "target": method,
+                        "evidence": method,
+                        "file": self.file,
+                        "line": node.lineno,
+                    }
+                )
+        self.generic_visit(node)
+
+    def _arg_value(
+        self, call: ast.Call, spec: int | str, string_only: bool = False
+    ) -> str | None:
+        node: ast.AST | None = None
+        if isinstance(spec, int):
+            if spec < len(call.args):
+                node = call.args[spec]
+        else:
+            node = next((kw.value for kw in call.keywords if kw.arg == spec), None)
+        if node is None:
+            return None
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            return node.value
+        if not string_only:
+            return _dotted(node)
+        return None
+
+    def visit_Constant(self, node) -> None:
+        if isinstance(node.value, str) and _QUALNAME_RE.match(node.value):
+            self.literals.append(
+                {
+                    "value": node.value,
+                    "scope": self._here(),
+                    "file": self.file,
+                    "line": node.lineno,
+                }
+            )
+
+
+def resolve_qualname_literals(literals: list[dict], qualnames: set[str]) -> list[dict]:
+    """Candidate edges for string literals that exactly match indexed qualnames."""
+    out: list[dict] = []
+    for lit in literals:
+        if lit["value"] in qualnames and lit["value"] != lit["scope"]:
+            out.append(
+                {
+                    "kind": "candidate",
+                    "via": "qualname_literal",
+                    "source": lit["scope"],
+                    "target": lit["value"],
+                    "evidence": lit["value"],
+                    "file": lit["file"],
+                    "line": lit["line"],
+                }
+            )
+    return out
+
+
+def _configured(manifest: ConventionManifest) -> bool:
+    return bool(
+        manifest.decorator_registries
+        or manifest.string_registries
+        or manifest.registration_calls
+        or manifest.string_dispatchers
+    )
+
+
+def extract_registrations(
+    source: str | Path, manifest: ConventionManifest
+) -> dict[str, list[dict]]:
+    """Walk manifest Python dirs; return {"records", "candidate_edges"}."""
+    if not _configured(manifest):
+        return {"records": [], "candidate_edges": []}
+
+    src = Path(source)
+    records: list[dict] = []
+    edges: list[dict] = []
+    literals: list[dict] = []
+    qualnames: set[str] = set()
+
+    for d in manifest.python_search_dirs or ("",):
+        root = src / d if d else src
+        if not root.exists():
+            continue
+        for py in root.rglob("*.py"):
+            path_str = str(py)
+            if any(p in path_str.lower() for p in manifest.exclude_patterns):
+                continue
+            try:
+                tree = ast.parse(
+                    py.read_text(encoding="utf-8", errors="replace"),
+                    filename=path_str,
+                )
+            except SyntaxError:
+                continue
+            rel = str(py.relative_to(src))
+            visitor = _FileVisitor(manifest, _module_name(rel), rel)
+            visitor.visit(tree)
+            records.extend(visitor.records)
+            edges.extend(visitor.candidate_edges)
+            literals.extend(visitor.literals)
+            qualnames.update(visitor.qualnames)
+
+    edges.extend(resolve_qualname_literals(literals, qualnames))
+    return {"records": records, "candidate_edges": edges}

--- a/src/torchtalk/analysis/patterns.py
+++ b/src/torchtalk/analysis/patterns.py
@@ -96,17 +96,17 @@ TEST_UTILITY_MODULES = [
 ]
 
 
-def should_exclude(path: str) -> bool:
-    return any(p in path.lower() for p in EXCLUDE_PATTERNS)
+def should_exclude(path: str, patterns: tuple[str, ...] | None = None) -> bool:
+    return any(p in path.lower() for p in (patterns or EXCLUDE_PATTERNS))
 
 
 def should_include_dir(file_path: str, include_dirs: list[str]) -> bool:
     return any(d in file_path for d in include_dirs)
 
 
-def has_binding_patterns(content: str) -> bool:
-    return any(p in content for p in CPP_BINDING_PATTERNS)
+def has_binding_patterns(content: str, patterns: tuple[str, ...] | None = None) -> bool:
+    return any(p in content for p in (patterns or CPP_BINDING_PATTERNS))
 
 
-def has_test_patterns(content: str) -> bool:
-    return any(p in content for p in TEST_CONTENT_PATTERNS)
+def has_test_patterns(content: str, patterns: tuple[str, ...] | None = None) -> bool:
+    return any(p in content for p in (patterns or TEST_CONTENT_PATTERNS))

--- a/src/torchtalk/analysis/python_analyzer.py
+++ b/src/torchtalk/analysis/python_analyzer.py
@@ -118,9 +118,14 @@ class PyModule:
 class PythonAnalyzer:
     """Analyzes Python source code using AST."""
 
-    def __init__(self, alias_map: dict[str, str] | None = None):
+    def __init__(
+        self,
+        alias_map: dict[str, str] | None = None,
+        package_roots: tuple[str, ...] | None = None,
+    ):
         self._module_cache: dict[str, PyModule] = {}
         self._alias_map = alias_map
+        self._package_roots = package_roots or ("torch", "torchvision", "torchaudio")
 
     def analyze_file(self, file_path: str) -> PyModule | None:
         """Analyze a single Python file."""
@@ -177,10 +182,9 @@ class PythonAnalyzer:
 
     def _path_to_module_name(self, path: Path) -> str:
         """Convert file path to Python module name."""
-        # Try to find torch/ or similar package root
         parts = path.parts
         for i, part in enumerate(parts):
-            if part in ("torch", "torchvision", "torchaudio"):
+            if part in self._package_roots:
                 # Build module name from this point
                 module_parts = list(parts[i:])
                 # Remove .py extension

--- a/src/torchtalk/cli.py
+++ b/src/torchtalk/cli.py
@@ -179,8 +179,11 @@ def cmd_status(args):
 def cmd_mcp_serve(args):
     """Start MCP server for Claude Code integration."""
     from torchtalk.formatting import set_formatter_mode
+    from torchtalk.harness import set_active_harness
     from torchtalk.server import run_server
 
+    if args.harness:
+        set_active_harness(args.harness)
     set_formatter_mode(args.format)
     run_server(
         pytorch_source=args.pytorch_source,
@@ -193,8 +196,11 @@ def cmd_mcp_serve(args):
 def cmd_index_build(args):
     """Build or refresh the index for a PyTorch source and exit."""
     from torchtalk.config import resolve_pytorch_source
+    from torchtalk.harness import set_active_harness
     from torchtalk.indexer import build_index
 
+    if args.harness:
+        set_active_harness(args.harness)
     source = args.pytorch_source or resolve_pytorch_source()
     if not source:
         log.error("No PyTorch source configured. Run 'torchtalk init' first.")
@@ -592,6 +598,10 @@ Example:
         action="store_true",
         help="Return immediately instead of waiting for the C++ call graph",
     )
+    p_build.add_argument(
+        "--harness",
+        help="Harness to index with (default: pytorch)",
+    )
     p_build.set_defaults(func=cmd_index_build)
 
     p_update = index_sub.add_parser(
@@ -642,6 +652,10 @@ First run builds the index (a few minutes); subsequent runs use cache.
         default="stdio",
         choices=["stdio", "streamable-http"],
         help="MCP transport type (default: stdio for Claude Code)",
+    )
+    parser_mcp.add_argument(
+        "--harness",
+        help="Harness to index with (default: pytorch)",
     )
     parser_mcp.add_argument(
         "--format",

--- a/src/torchtalk/cli.py
+++ b/src/torchtalk/cli.py
@@ -3,7 +3,7 @@
 TorchTalk CLI - Cross-language binding analysis for PyTorch codebases.
 
 Quick start:
-    torchtalk init --pytorch-source /path/to/pytorch
+    torchtalk init --source /path/to/pytorch
     claude mcp add torchtalk -s user -- torchtalk mcp-serve
 
 The MCP server automatically builds and caches the binding index on first run.
@@ -19,30 +19,57 @@ from pathlib import Path
 log = logging.getLogger(__name__)
 
 
+def _activate_harness(name: str | None) -> bool:
+    """Activate the named harness, or the configured default when name is None.
+
+    Returns False (after logging) when the harness is not registered.
+    """
+    from torchtalk.config import default_harness
+    from torchtalk.harness import set_active_harness
+
+    target = name or default_harness()
+    if not target:
+        return True
+    try:
+        set_active_harness(target)
+    except KeyError as e:
+        log.error(str(e))
+        return False
+    return True
+
+
 def cmd_init(args):
-    """Configure TorchTalk with PyTorch source path."""
-    from torchtalk.config import load_config, save_config, validate_pytorch_path
+    """Configure TorchTalk with a source path for a harness."""
+    from torchtalk.config import set_source, validate_source_path
+    from torchtalk.harness import get_harness
 
-    source_path = str(Path(args.pytorch_source).resolve())
+    try:
+        manifest = get_harness(args.harness).manifest
+    except KeyError as e:
+        log.error(str(e))
+        sys.exit(1)
 
-    valid, msg = validate_pytorch_path(source_path)
+    source_path = str(Path(args.source).resolve())
+
+    valid, msg = validate_source_path(source_path, manifest)
     if not valid:
         log.error(msg)
         sys.exit(1)
 
-    config = load_config()
-    config.setdefault("source", {})["pytorch_source"] = source_path
-    path = save_config(config)
+    path = set_source(args.harness, source_path, make_default=args.set_default)
 
+    default_note = f"  default harness = {args.harness}\n" if args.set_default else ""
     log.info(
         "Config saved to %s\n"
-        "  pytorch_source = %s\n\n"
+        "  sources.%s = %s\n%s\n"
         "Next steps:\n"
         "  claude mcp add torchtalk -s user -- torchtalk mcp-serve\n\n"
         "Verify with:\n"
         "  torchtalk status",
         path,
+        args.harness,
         source_path,
+        default_note,
     )
 
 
@@ -70,108 +97,108 @@ def _format_coverage(cov: dict[str, int]) -> str:
     return " / ".join(parts + extras) if (parts or extras) else "unknown"
 
 
-def cmd_status(args):
-    """Show TorchTalk configuration and cache status."""
+def _configured_sources(config: dict) -> dict[str, str]:
+    """Harness → source path from config, folding in the legacy pytorch key."""
+    sources = dict(config.get("sources", {}))
+    legacy = config.get("source", {}).get("pytorch_source")
+    if legacy and "pytorch" not in sources:
+        sources["pytorch"] = legacy
+    return sources
+
+
+def _harness_status_lines(harness: str, config_source: str) -> tuple[list[str], bool]:
+    """Status lines for one configured harness; returns (lines, is_valid)."""
     from datetime import datetime
 
-    from torchtalk import __version__
-    from torchtalk.config import (
-        CACHE_DIR,
-        CONFIG_FILE,
-        cache_paths,
-        load_config,
-        resolve_pytorch_source,
-        validate_pytorch_path,
+    from torchtalk.config import cache_paths, validate_source_path
+    from torchtalk.harness import get_harness
+
+    lines = [f"Harness: {harness}"]
+    try:
+        manifest = get_harness(harness).manifest
+    except KeyError:
+        lines.append(f"  Source:          {config_source} (UNREGISTERED harness)")
+        return lines, False
+
+    valid, msg = validate_source_path(config_source, manifest)
+    lines.append(
+        f"  Source:          {config_source} ({'valid' if valid else 'INVALID'})"
     )
+    if not valid:
+        lines.append(f"                   {msg}")
+        return lines, False
+
+    paths = cache_paths(config_source, package=manifest.package)
+    for key, label in [("bindings", "Bindings index"), ("callgraph", "Call graph")]:
+        p = paths[key]
+        if p.exists():
+            size_mb = p.stat().st_size / (1024 * 1024)
+            mtime = datetime.fromtimestamp(p.stat().st_mtime)
+            lines.append(
+                f"  {label + ':':18s} {p.name} "
+                f"({size_mb:.1f} MB, {mtime:%Y-%m-%d %H:%M})"
+            )
+            if key == "callgraph":
+                stats = _read_cache_stats(p) or {}
+                cov = stats.get("coverage")
+                if cov:
+                    lines.append(f"  {'TU coverage:':18s} " + _format_coverage(cov))
+                idirs = stats.get("include_dirs_count")
+                if isinstance(idirs, int) and idirs > 0:
+                    lines.append(f"  {'-I dirs tracked:':18s} {idirs}")
+        else:
+            lines.append(f"  {label + ':':18s} not built")
+
+    compile_cmds = Path(config_source) / "build" / "compile_commands.json"
+    if not compile_cmds.exists():
+        compile_cmds = Path(config_source) / "compile_commands.json"
+    found = "found" if compile_cmds.exists() else "not found (call graph unavailable)"
+    lines.append(f"  compile_commands.json: {found}")
+    return lines, True
+
+
+def cmd_status(args):
+    """Show TorchTalk configuration and cache status."""
+    from torchtalk import __version__
+    from torchtalk.config import CACHE_DIR, CONFIG_FILE, default_harness, load_config
 
     lines = [f"TorchTalk v{__version__}", ""]
 
-    # Config file
     lines.append("Configuration:")
     if not CONFIG_FILE.exists():
         lines.append(f"  Config file:     {CONFIG_FILE} (not found)")
         lines.append("")
-        lines.append(
-            "Run 'torchtalk init --pytorch-source /path/to/pytorch' to configure."
-        )
+        lines.append("Run 'torchtalk init --source /path/to/pytorch' to configure.")
         print("\n".join(lines))
         sys.exit(1)
 
     lines.append(f"  Config file:     {CONFIG_FILE}")
+    lines.append(f"  Cache directory: {CACHE_DIR}")
+    default = default_harness()
+    if default:
+        lines.append(f"  Default harness: {default}")
 
-    # PyTorch source — show raw config value for diagnostics, even if stale
-    config = load_config()
-    config_source = config.get("source", {}).get("pytorch_source")
-
-    if not config_source:
-        lines.append("  PyTorch source:  not configured")
+    # Show raw config values for diagnostics, even if stale
+    sources = _configured_sources(load_config())
+    if not sources:
+        lines.append("  Sources:         not configured")
         lines.append("")
-        lines.append(
-            "Run 'torchtalk init --pytorch-source /path/to/pytorch' to configure."
-        )
+        lines.append("Run 'torchtalk init --source /path/to/pytorch' to configure.")
         print("\n".join(lines))
         sys.exit(1)
 
-    valid, msg = validate_pytorch_path(config_source)
-    lines.append(
-        f"  PyTorch source:  {config_source} ({'valid' if valid else 'INVALID'})"
-    )
-    if not valid:
-        lines.append(f"                   {msg}")
+    all_valid = True
+    for harness in sorted(sources):
         lines.append("")
-        lines.append(
-            "Run 'torchtalk init --pytorch-source /path/to/pytorch' to reconfigure."
-        )
+        harness_lines, valid = _harness_status_lines(harness, sources[harness])
+        lines.extend(harness_lines)
+        all_valid = all_valid and valid
+
+    lines.append("")
+    if not all_valid:
+        lines.append("Status: NOT READY (fix the entries above or re-run init)")
         print("\n".join(lines))
         sys.exit(1)
-
-    source = resolve_pytorch_source()
-
-    # Cache
-    lines.append("")
-    lines.append("Cache:")
-    lines.append(f"  Cache directory:  {CACHE_DIR}")
-
-    if CACHE_DIR.exists():
-        paths = cache_paths(source)
-        for key, label in [("bindings", "Bindings index"), ("callgraph", "Call graph")]:
-            p = paths[key]
-            if p.exists():
-                size_mb = p.stat().st_size / (1024 * 1024)
-                mtime = datetime.fromtimestamp(p.stat().st_mtime)
-                lines.append(
-                    f"  {label + ':':18s} {p.name} "
-                    f"({size_mb:.1f} MB, {mtime:%Y-%m-%d %H:%M})"
-                )
-                if key == "callgraph":
-                    stats = _read_cache_stats(p) or {}
-                    cov = stats.get("coverage")
-                    if cov:
-                        lines.append(f"  {'TU coverage:':18s} " + _format_coverage(cov))
-                    idirs = stats.get("include_dirs_count")
-                    if isinstance(idirs, int) and idirs > 0:
-                        lines.append(f"  {'-I dirs tracked:':18s} {idirs}")
-            else:
-                lines.append(f"  {label + ':':18s} not built")
-    else:
-        lines.append("  Cache directory:  not created yet")
-
-    # compile_commands.json
-    if source:
-        compile_cmds = Path(source) / "build" / "compile_commands.json"
-        lines.append("")
-        lines.append("Build artifacts:")
-        if compile_cmds.exists():
-            lines.append("  compile_commands.json: found")
-        else:
-            lines.append(
-                "  compile_commands.json: not found (call graph features unavailable)"
-            )
-            lines.append(
-                f"    Build PyTorch to enable: cd {source} && python setup.py develop"
-            )
-
-    lines.append("")
     lines.append("Status: Ready")
     print("\n".join(lines))
 
@@ -179,14 +206,13 @@ def cmd_status(args):
 def cmd_mcp_serve(args):
     """Start MCP server for Claude Code integration."""
     from torchtalk.formatting import set_formatter_mode
-    from torchtalk.harness import set_active_harness
     from torchtalk.server import run_server
 
-    if args.harness:
-        set_active_harness(args.harness)
+    if not _activate_harness(args.harness):
+        return 1
     set_formatter_mode(args.format)
     run_server(
-        pytorch_source=args.pytorch_source,
+        pytorch_source=args.source,
         index_path=args.index,
         transport=args.transport,
     )
@@ -194,16 +220,15 @@ def cmd_mcp_serve(args):
 
 
 def cmd_index_build(args):
-    """Build or refresh the index for a PyTorch source and exit."""
-    from torchtalk.config import resolve_pytorch_source
-    from torchtalk.harness import set_active_harness
+    """Build or refresh the index for a source checkout and exit."""
+    from torchtalk.config import resolve_source
     from torchtalk.indexer import build_index
 
-    if args.harness:
-        set_active_harness(args.harness)
-    source = args.pytorch_source or resolve_pytorch_source()
+    if not _activate_harness(args.harness):
+        return 1
+    source = resolve_source(cli_flag=args.source)
     if not source:
-        log.error("No PyTorch source configured. Run 'torchtalk init' first.")
+        log.error("No source configured. Run 'torchtalk init' first.")
         return 1
 
     stats = build_index(source, wait_for_cpp=not args.no_wait)
@@ -224,13 +249,15 @@ def cmd_index_build(args):
 
 def cmd_index_update(args):
     """Incrementally refresh the bindings index using a snapshot as baseline."""
-    from torchtalk.config import resolve_pytorch_source
+    from torchtalk.config import resolve_source
     from torchtalk.indexer import update_index
     from torchtalk.snapshots import SnapshotError
 
-    source = args.pytorch_source or resolve_pytorch_source()
+    if not _activate_harness(args.harness):
+        return 1
+    source = resolve_source(cli_flag=args.source)
     if not source:
-        log.error("No PyTorch source configured. Run 'torchtalk init' first.")
+        log.error("No source configured. Run 'torchtalk init' first.")
         return 1
 
     try:
@@ -296,6 +323,8 @@ def cmd_snapshot_save(args):
     """Save current cache as a named snapshot."""
     from torchtalk.snapshots import SnapshotError, save_snapshot
 
+    if not _activate_harness(args.harness):
+        return 1
     try:
         manifest = save_snapshot(args.name)
     except SnapshotError as e:
@@ -314,6 +343,8 @@ def cmd_snapshot_load(args):
     """Load a named snapshot into the active cache."""
     from torchtalk.snapshots import SnapshotError, find_nearest_snapshot, load_snapshot
 
+    if not _activate_harness(args.harness):
+        return 1
     name = args.name
     force = args.force
 
@@ -497,9 +528,9 @@ def cmd_cursor_add(args):
     else:
         config_path = cursor_dir / MCP_CONFIG_NAME
 
-    pytorch_source = Path(args.pytorch_source).resolve()
-    if not pytorch_source.is_dir():
-        log.error("PyTorch source path is not a directory: %s", pytorch_source)
+    source = Path(args.source).resolve()
+    if not source.is_dir():
+        log.error("Source path is not a directory: %s", source)
         return 1
 
     if config_path.exists():
@@ -516,7 +547,7 @@ def cmd_cursor_add(args):
 
     data["mcpServers"]["torchtalk"] = {
         "command": "torchtalk",
-        "args": ["mcp-serve", "--pytorch-source", str(pytorch_source)],
+        "args": ["mcp-serve", "--source", str(source)],
     }
 
     config_dir = config_path.parent
@@ -541,7 +572,7 @@ def main():
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Quick start:
-  torchtalk init --pytorch-source /path/to/pytorch
+  torchtalk init --source /path/to/pytorch
   claude mcp add torchtalk -s user -- torchtalk mcp-serve
 
 Verify setup:
@@ -554,21 +585,35 @@ Verify setup:
     # init command
     parser_init = subparsers.add_parser(
         "init",
-        help="Configure TorchTalk with PyTorch source path",
+        help="Configure TorchTalk with a source path for a harness",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Saves configuration to ~/.config/torchtalk/config.toml.
 Safe to re-run -- updates existing config without data loss.
+Run once per harness to configure multiple repos side by side.
 
-Example:
-  torchtalk init --pytorch-source /myworkspace/pytorch
+Examples:
+  torchtalk init --source /myworkspace/pytorch
+  torchtalk init --harness vllm --source /myworkspace/vllm --set-default
         """,
     )
     parser_init.add_argument(
+        "--source",
         "--pytorch-source",
         "-p",
+        dest="source",
         required=True,
-        help="Path to PyTorch source code",
+        help="Path to the source checkout (--pytorch-source is a deprecated alias)",
+    )
+    parser_init.add_argument(
+        "--harness",
+        default="pytorch",
+        help="Harness the source belongs to (default: pytorch)",
+    )
+    parser_init.add_argument(
+        "--set-default",
+        action="store_true",
+        help="Make this harness the default when --harness is omitted",
     )
     parser_init.add_argument(
         "--debug", action="store_true", help="Enable debug logging"
@@ -589,9 +634,11 @@ Example:
     index_sub = parser_index.add_subparsers(dest="index_cmd", required=True)
     p_build = index_sub.add_parser("build", help="Build or refresh the index and exit")
     p_build.add_argument(
+        "--source",
         "--pytorch-source",
         "-p",
-        help="Override PyTorch source (default: from config)",
+        dest="source",
+        help="Override source path (default: from config)",
     )
     p_build.add_argument(
         "--no-wait",
@@ -600,7 +647,7 @@ Example:
     )
     p_build.add_argument(
         "--harness",
-        help="Harness to index with (default: pytorch)",
+        help="Harness to index with (default: from config, else pytorch)",
     )
     p_build.set_defaults(func=cmd_index_build)
 
@@ -613,9 +660,11 @@ Example:
         "--since", required=True, help="Baseline snapshot name (e.g. 'nightly')"
     )
     p_update.add_argument(
+        "--source",
         "--pytorch-source",
         "-p",
-        help="Override PyTorch source (default: from config)",
+        dest="source",
+        help="Override source path (default: from config)",
     )
     p_update.add_argument(
         "--on-uncovered",
@@ -627,6 +676,10 @@ Example:
             "widen (textually grep compile-DB TUs and add to reparse set)"
         ),
     )
+    p_update.add_argument(
+        "--harness",
+        help="Harness to update with (default: from config, else pytorch)",
+    )
     p_update.set_defaults(func=cmd_index_update)
 
     # mcp-serve command
@@ -635,14 +688,16 @@ Example:
         help="Start MCP server for Claude Code integration",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
-Reads PyTorch source from config. Override with --pytorch-source flag.
+Reads the harness's source from config. Override with --source flag.
 First run builds the index (a few minutes); subsequent runs use cache.
         """,
     )
     parser_mcp.add_argument(
+        "--source",
         "--pytorch-source",
         "-p",
-        help="Override PyTorch source path (default: from config)",
+        dest="source",
+        help="Override source path (default: from config)",
     )
     parser_mcp.add_argument(
         "--index", "-i", help="Path to existing bindings.json or index directory"
@@ -655,7 +710,7 @@ First run builds the index (a few minutes); subsequent runs use cache.
     )
     parser_mcp.add_argument(
         "--harness",
-        help="Harness to index with (default: pytorch)",
+        help="Harness to index with (default: from config, else pytorch)",
     )
     parser_mcp.add_argument(
         "--format",
@@ -678,6 +733,10 @@ First run builds the index (a few minutes); subsequent runs use cache.
         "name",
         help="Name (letters, digits, . - _ ; max 64 chars)",
     )
+    p_save.add_argument(
+        "--harness",
+        help="Harness whose cache to snapshot (default: from config, else pytorch)",
+    )
     p_save.set_defaults(func=cmd_snapshot_save)
 
     p_load = snap_sub.add_parser("load", help="Restore a snapshot into active cache")
@@ -693,6 +752,10 @@ First run builds the index (a few minutes); subsequent runs use cache.
         "--nearest",
         action="store_true",
         help="Auto-pick the snapshot whose git commit best matches current HEAD",
+    )
+    p_load.add_argument(
+        "--harness",
+        help="Harness whose cache to restore into (default: from config, else pytorch)",
     )
     p_load.set_defaults(func=cmd_snapshot_load)
 
@@ -747,10 +810,12 @@ First run builds the index (a few minutes); subsequent runs use cache.
         help="Project root: .cursor/mcp.json and .claude contents are written here",
     )
     parser_cursor.add_argument(
+        "--source",
         "--pytorch-source",
         "-p",
+        dest="source",
         required=True,
-        help="Path to PyTorch source tree",
+        help="Path to the source checkout (--pytorch-source is a deprecated alias)",
     )
     parser_cursor.add_argument(
         "--global",

--- a/src/torchtalk/config.py
+++ b/src/torchtalk/config.py
@@ -3,16 +3,27 @@
 Manages user config at ~/.config/torchtalk/config.toml (XDG-compliant)
 and cache at ~/.cache/torchtalk/.
 
-Resolution order for pytorch_source:
-  1. --pytorch-source CLI flag (highest priority)
-  2. PYTORCH_SOURCE environment variable
-  3. ~/.config/torchtalk/config.toml
+Source paths are configured per harness under [sources] (keyed by harness
+name), with [defaults] harness selecting the harness used when --harness is
+omitted. Resolution order for a harness's source:
+  1. --source CLI flag (highest priority)
+  2. TORCHTALK_SOURCE_<HARNESS> environment variable
+     (plus PYTORCH_SOURCE / PYTORCH_PATH for the pytorch harness)
+  3. [sources].<harness> in config.toml
+     (plus the legacy [source] pytorch_source key for the pytorch harness)
 """
+
+from __future__ import annotations
 
 import logging
 import os
+import re
 import sys
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .harness import ConventionManifest
 
 if sys.version_info >= (3, 11):
     import tomllib
@@ -73,29 +84,68 @@ def save_config(config: dict) -> Path:
     return CONFIG_FILE
 
 
-def resolve_pytorch_source(cli_flag: str | None = None) -> str | None:
-    """Resolve PyTorch source path using 3-level priority.
+def source_env_var(harness: str) -> str:
+    """Environment variable naming a harness's source override."""
+    return "TORCHTALK_SOURCE_" + re.sub(r"[^A-Za-z0-9]", "_", harness).upper()
 
-    1. cli_flag (--pytorch-source)
-    2. PYTORCH_SOURCE env var
-    3. config.toml [source] pytorch_source
+
+def resolve_source(
+    harness: str | None = None, cli_flag: str | None = None
+) -> str | None:
+    """Resolve a harness's source path using 3-level priority.
+
+    1. cli_flag (--source)
+    2. TORCHTALK_SOURCE_<HARNESS> env var (pytorch also honors the legacy
+       PYTORCH_SOURCE / PYTORCH_PATH vars)
+    3. config.toml [sources].<harness> (pytorch also honors the legacy
+       [source] pytorch_source key)
+
+    `harness` defaults to the active harness.
     """
-    # Level 1: CLI flag
     if cli_flag:
         return cli_flag
 
-    # Level 2: Environment variable
-    env_val = os.environ.get("PYTORCH_SOURCE") or os.environ.get("PYTORCH_PATH")
-    if env_val and Path(env_val).exists():
-        return env_val
+    if harness is None:
+        from .harness import active_harness_name
 
-    # Level 3: Config file
+        harness = active_harness_name()
+
+    env_vars = [source_env_var(harness)]
+    if harness == "pytorch":
+        env_vars += ["PYTORCH_SOURCE", "PYTORCH_PATH"]
+    for var in env_vars:
+        val = os.environ.get(var)
+        if val and Path(val).exists():
+            return val
+
     config = load_config()
-    config_val = config.get("source", {}).get("pytorch_source")
+    config_val = config.get("sources", {}).get(harness)
+    if not config_val and harness == "pytorch":
+        config_val = config.get("source", {}).get("pytorch_source")
     if config_val and Path(config_val).exists():
         return config_val
 
     return None
+
+
+def default_harness() -> str | None:
+    """The configured default harness name, or None when unset."""
+    return load_config().get("defaults", {}).get("harness")
+
+
+def set_source(harness: str, path: str, make_default: bool = False) -> Path:
+    """Record a harness's source path in config.toml; returns the path written.
+
+    Mirrors the pytorch entry to the legacy [source] pytorch_source key,
+    which older readers (e.g. plugin-setup.sh) grep for.
+    """
+    config = load_config()
+    config.setdefault("sources", {})[harness] = path
+    if harness == "pytorch":
+        config.setdefault("source", {})["pytorch_source"] = path
+    if make_default:
+        config.setdefault("defaults", {})["harness"] = harness
+    return save_config(config)
 
 
 def source_hash(source: str | Path) -> str:
@@ -109,24 +159,34 @@ def source_hash(source: str | Path) -> str:
     return hashlib.md5(str(Path(source).resolve()).encode()).hexdigest()[:12]
 
 
-def cache_paths(source: str | Path) -> dict[str, Path]:
-    """Return the canonical cache file paths for a given source directory.
+def cache_paths(source: str | Path, package: str | None = None) -> dict[str, Path]:
+    """Return the canonical cache file paths for a source directory and package.
+
+    Paths are qualified by both source hash and harness package so indexing
+    the same checkout under different harnesses never shares cache files.
 
     Keys:
         bindings  - Binding index JSON
         callgraph - C++ call graph JSON
     """
+    if package is None:
+        from .harness import active_manifest
+
+        package = active_manifest().package
     h = source_hash(source)
+    callgraph_dir = CACHE_DIR / "call_graph"
     return {
-        "bindings": CACHE_DIR / f"bindings_{h}.json",
-        "callgraph": CACHE_DIR / "call_graph" / f"pytorch_callgraph_parallel_{h}.json",
-        "test_infra": CACHE_DIR / f"test_infra_{h}.json",
-        "py_cpp_edges": CACHE_DIR / f"py_cpp_edges_{h}.json",
+        "bindings": CACHE_DIR / f"bindings_{package}_{h}.json",
+        "callgraph": callgraph_dir / f"{package}_callgraph_parallel_{h}.json",
+        "test_infra": CACHE_DIR / f"test_infra_{package}_{h}.json",
+        "py_cpp_edges": CACHE_DIR / f"py_cpp_edges_{package}_{h}.json",
     }
 
 
-def validate_pytorch_path(path: str | Path) -> tuple[bool, str]:
-    """Validate that a path looks like a PyTorch source checkout.
+def validate_source_path(
+    path: str | Path, manifest: ConventionManifest
+) -> tuple[bool, str]:
+    """Validate that a path looks like a checkout of the manifest's package.
 
     Returns (is_valid, message).
     """
@@ -135,12 +195,18 @@ def validate_pytorch_path(path: str | Path) -> tuple[bool, str]:
         return False, f"Path does not exist: {p}"
     if not p.is_dir():
         return False, f"Path is not a directory: {p}"
-    if not (p / "torch").exists():
-        return False, f"No 'torch/' directory found in {p} (not a PyTorch checkout?)"
-    nf = p / "aten" / "src" / "ATen" / "native" / "native_functions.yaml"
-    if not nf.exists():
-        return (
-            False,
-            f"native_functions.yaml not found in {p} (required for operator indexing)",
+    roots = (*manifest.python_package_roots, *manifest.cpp_search_dirs)
+    if roots and not any((p / d).exists() for d in roots):
+        return False, (
+            f"No {manifest.package} directories ({', '.join(sorted(set(roots)))}) "
+            f"found in {p} (not a {manifest.package} checkout?)"
         )
-    return True, f"Valid PyTorch source: {p}"
+    if manifest.native_functions_yaml:
+        nf = p / manifest.native_functions_yaml
+        if not nf.exists():
+            return (
+                False,
+                f"{manifest.native_functions_yaml} not found in {p} "
+                "(required for operator indexing)",
+            )
+    return True, f"Valid {manifest.package} source: {p}"

--- a/src/torchtalk/formatting.py
+++ b/src/torchtalk/formatting.py
@@ -159,7 +159,11 @@ def relative_path(full_path: str, base: str | None = None) -> str:
 
     prefixes = ["pytorch/"]
     if base:
-        prefixes.insert(0, base.rstrip("/") + "/")
+        base_clean = base.rstrip("/")
+        prefixes.insert(0, base_clean + "/")
+        checkout_name = base_clean.rsplit("/", 1)[-1]
+        if checkout_name and f"{checkout_name}/" not in prefixes:
+            prefixes.append(f"{checkout_name}/")
 
     for prefix in prefixes:
         if full_path.startswith(prefix):

--- a/src/torchtalk/harness.py
+++ b/src/torchtalk/harness.py
@@ -15,6 +15,7 @@ from .analysis.patterns import (
     CPP_SEARCH_DIRS,
     EXCLUDE_PATTERNS,
     PYTHON_SEARCH_DIRS,
+    TEST_CONTENT_PATTERNS,
     TEST_SEARCH_DIRS,
     TEST_UTILITY_MODULES,
 )
@@ -40,12 +41,13 @@ class ConventionManifest:
     # top-level import-package dirs used to derive module names from paths
     python_package_roots: tuple[str, ...] = ()
     test_search_dirs: tuple[str, ...] = ()
+    # content markers identifying test files in package-internal test dirs
+    test_content_patterns: tuple[str, ...] = ("TestCase", "pytest", "unittest")
     test_utility_modules: tuple[str, ...] = ()
     exclude_patterns: tuple[str, ...] = ()
     registration_macros: tuple[str, ...] = ()
     native_functions_yaml: str = ""
     derivatives_yaml: str = ""
-    cache_identity: str = "git"
     # C++ extractor config: alias macro → canonical macro it expands to
     # (e.g. {"TORCH_LIBRARY_EXPAND": "TORCH_LIBRARY"}), and token → literal
     # substitutions (e.g. {"TORCH_EXTENSION_NAME": "_C"}).
@@ -74,6 +76,7 @@ PYTORCH_MANIFEST = ConventionManifest(
     python_search_dirs=tuple(PYTHON_SEARCH_DIRS),
     python_package_roots=("torch",),
     test_search_dirs=tuple(TEST_SEARCH_DIRS),
+    test_content_patterns=tuple(TEST_CONTENT_PATTERNS),
     test_utility_modules=tuple(TEST_UTILITY_MODULES),
     exclude_patterns=tuple(EXCLUDE_PATTERNS),
     registration_macros=tuple(CPP_BINDING_PATTERNS),
@@ -163,6 +166,11 @@ def set_active_harness(name: str) -> None:
     if name not in _REGISTRY:
         raise KeyError(f"Unknown harness {name!r}. Registered: {sorted(_REGISTRY)}")
     _ACTIVE = name
+
+
+def active_harness_name() -> str:
+    """Name of the harness used when get_harness() is called without a name."""
+    return _ACTIVE
 
 
 def active_manifest() -> ConventionManifest:

--- a/src/torchtalk/harness.py
+++ b/src/torchtalk/harness.py
@@ -1,0 +1,174 @@
+"""Repo harnesses: convention manifests describing how to index a package.
+
+A manifest is data, not code: search directories, exclusion patterns,
+data-source paths, and cache-identity strategy for one package. Graphs built
+from different manifests merge via package-qualified symbol IDs (symbols.py).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Protocol, runtime_checkable
+
+from .analysis.patterns import (
+    CPP_BINDING_PATTERNS,
+    CPP_SEARCH_DIRS,
+    EXCLUDE_PATTERNS,
+    PYTHON_SEARCH_DIRS,
+    TEST_SEARCH_DIRS,
+    TEST_UTILITY_MODULES,
+)
+
+
+@dataclass(frozen=True)
+class CallRegistration:
+    """A registration call: which arg holds the registry key, which the target."""
+
+    call: str
+    key_arg: int | str
+    target_arg: int | str
+    registry: str = ""
+
+
+@dataclass(frozen=True)
+class ConventionManifest:
+    """Indexing conventions for one package."""
+
+    package: str
+    cpp_search_dirs: tuple[str, ...]
+    python_search_dirs: tuple[str, ...] = ()
+    # top-level import-package dirs used to derive module names from paths
+    python_package_roots: tuple[str, ...] = ()
+    test_search_dirs: tuple[str, ...] = ()
+    test_utility_modules: tuple[str, ...] = ()
+    exclude_patterns: tuple[str, ...] = ()
+    registration_macros: tuple[str, ...] = ()
+    native_functions_yaml: str = ""
+    derivatives_yaml: str = ""
+    cache_identity: str = "git"
+    # C++ extractor config: alias macro → canonical macro it expands to
+    # (e.g. {"TORCH_LIBRARY_EXPAND": "TORCH_LIBRARY"}), and token → literal
+    # substitutions (e.g. {"TORCH_EXTENSION_NAME": "_C"}).
+    cpp_macro_aliases: dict[str, str] = field(default_factory=dict)
+    cpp_token_map: dict[str, str] = field(default_factory=dict)
+    # Python extractor config (analysis/extractors.py):
+    # decorator qualname → registry it populates
+    decorator_registries: dict[str, str] = field(default_factory=dict)
+    # module-level dict variables mapping string keys to import targets
+    string_registries: tuple[str, ...] = ()
+    registration_calls: tuple[CallRegistration, ...] = ()
+    # dispatcher call → arg (position or kwarg) naming the invoked method
+    string_dispatchers: dict[str, int | str] = field(default_factory=dict)
+
+
+@runtime_checkable
+class Harness(Protocol):
+    """A package integration: its manifest (extractor hooks arrive later)."""
+
+    manifest: ConventionManifest
+
+
+PYTORCH_MANIFEST = ConventionManifest(
+    package="pytorch",
+    cpp_search_dirs=tuple(CPP_SEARCH_DIRS),
+    python_search_dirs=tuple(PYTHON_SEARCH_DIRS),
+    python_package_roots=("torch",),
+    test_search_dirs=tuple(TEST_SEARCH_DIRS),
+    test_utility_modules=tuple(TEST_UTILITY_MODULES),
+    exclude_patterns=tuple(EXCLUDE_PATTERNS),
+    registration_macros=tuple(CPP_BINDING_PATTERNS),
+    native_functions_yaml="aten/src/ATen/native/native_functions.yaml",
+    derivatives_yaml="tools/autograd/derivatives.yaml",
+    decorator_registries={"register_decomposition": "decompositions"},
+)
+
+
+@dataclass(frozen=True)
+class ManifestHarness:
+    """Harness defined entirely by manifest data."""
+
+    manifest: ConventionManifest
+
+
+PYTORCH_HARNESS = ManifestHarness(PYTORCH_MANIFEST)
+
+
+VLLM_MANIFEST = ConventionManifest(
+    package="vllm",
+    cpp_search_dirs=("csrc",),
+    python_search_dirs=("vllm",),
+    python_package_roots=("vllm",),
+    test_search_dirs=("tests",),
+    exclude_patterns=("/tests/", "/benchmarks/", "/examples/", "__pycache__"),
+    cpp_macro_aliases={
+        "TORCH_LIBRARY_EXPAND": "TORCH_LIBRARY",
+        "TORCH_LIBRARY_IMPL_EXPAND": "TORCH_LIBRARY_IMPL",
+    },
+    cpp_token_map={"TORCH_EXTENSION_NAME": "_C"},
+    decorator_registries={"CustomOp.register": "custom_ops"},
+    string_registries=(
+        "_TEXT_GENERATION_MODELS",
+        "_EMBEDDING_MODELS",
+        "_LATE_INTERACTION_MODELS",
+        "_REWARD_MODELS",
+        "_TOKEN_CLASSIFICATION_MODELS",
+        "_SEQUENCE_CLASSIFICATION_MODELS",
+        "_MULTIMODAL_MODELS",
+        "_SPECULATIVE_DECODING_MODELS",
+        "_TRANSFORMERS_SUPPORTED_MODELS",
+        "_TRANSFORMERS_BACKEND_MODELS",
+    ),
+    registration_calls=(
+        CallRegistration(
+            "direct_register_custom_op", "op_name", "op_func", "custom_ops"
+        ),
+        CallRegistration("direct_register_custom_op", 0, 1, "custom_ops"),
+    ),
+    string_dispatchers={"collective_rpc": 0},
+)
+
+TORCHVISION_MANIFEST = ConventionManifest(
+    package="torchvision",
+    cpp_search_dirs=("torchvision/csrc",),
+    python_search_dirs=("torchvision",),
+    python_package_roots=("torchvision",),
+    test_search_dirs=("test",),
+    exclude_patterns=tuple(EXCLUDE_PATTERNS),
+    cpp_macro_aliases={
+        "STABLE_TORCH_LIBRARY_FRAGMENT": "TORCH_LIBRARY_FRAGMENT",
+        "STABLE_TORCH_LIBRARY_IMPL": "TORCH_LIBRARY_IMPL",
+    },
+)
+
+_REGISTRY: dict[str, Harness] = {}
+_ACTIVE = "pytorch"
+
+
+def register_harness(name: str, harness: Harness) -> None:
+    """Register a harness under a package name."""
+    _REGISTRY[name] = harness
+
+
+def get_harness(name: str | None = None) -> Harness:
+    """Return the named harness, or the active one when no name is given."""
+    key = name or _ACTIVE
+    if key not in _REGISTRY:
+        raise KeyError(f"Unknown harness {key!r}. Registered: {sorted(_REGISTRY)}")
+    return _REGISTRY[key]
+
+
+def set_active_harness(name: str) -> None:
+    """Select the harness used when get_harness() is called without a name."""
+    global _ACTIVE
+    if name not in _REGISTRY:
+        raise KeyError(f"Unknown harness {name!r}. Registered: {sorted(_REGISTRY)}")
+    _ACTIVE = name
+
+
+def active_manifest() -> ConventionManifest:
+    return get_harness().manifest
+
+
+register_harness("pytorch", PYTORCH_HARNESS)
+register_harness("vllm", ManifestHarness(VLLM_MANIFEST))
+register_harness("torchvision", ManifestHarness(TORCHVISION_MANIFEST))

--- a/src/torchtalk/indexer.py
+++ b/src/torchtalk/indexer.py
@@ -13,19 +13,15 @@ from typing import Any
 
 from .analysis.helpers import fuzzy_distance_limit, levenshtein_distance, truncate
 from .analysis.patterns import (
-    CPP_SEARCH_DIRS,
-    PYTHON_SEARCH_DIRS,
-    TEST_SEARCH_DIRS,
-    TEST_UTILITY_MODULES,
-    is_vendor_path,
-)
-from .analysis.patterns import (
     has_test_patterns as _has_test_patterns,
 )
+from .analysis.patterns import is_vendor_path
 from .analysis.patterns import (
     should_exclude as _should_exclude,
 )
 from .config import CACHE_DIR, cache_paths, resolve_pytorch_source, source_hash
+from .harness import ConventionManifest, active_manifest
+from .symbols import PackageIdentity, content_fingerprint, detect_package_identity
 
 log = logging.getLogger(__name__)
 
@@ -40,6 +36,7 @@ class ServerState:
     derivatives: dict[str, dict] = field(default_factory=dict)
     native_implementations: dict[str, list[dict]] = field(default_factory=dict)
     symbol_to_file: dict[str, str] = field(default_factory=dict)
+    registrations: dict[str, list[dict]] = field(default_factory=dict)
 
     by_python_name: dict[str, list[dict]] = field(default_factory=dict)
     by_cpp_name: dict[str, list[dict]] = field(default_factory=dict)
@@ -69,6 +66,7 @@ class ServerState:
     dispatch_to_op: dict[str, str] = field(default_factory=dict)
 
     pytorch_source: str | None = None
+    package: PackageIdentity | None = None
     cpp_extractor: Any = None
     cpp_building: bool = False
     cpp_thread: Any = None
@@ -89,9 +87,7 @@ def _source_fingerprint(source: str) -> str:
     commits, pulls, and uncommitted edits all invalidate caches. Non-git
     checkouts fall back to mtime/size of version files.
     """
-    from .snapshots import _content_fingerprint
-
-    fp = _content_fingerprint(source) if source else None
+    fp = content_fingerprint(source) if source else None
     if fp:
         return fp
     src = Path(source)
@@ -109,17 +105,20 @@ def _source_fingerprint(source: str) -> str:
 
 
 # Bump when the bindings-cache schema changes (e.g. a new field added to
-# `native_functions` entries). v2 introduced `python_module`; v3 renamed
-# binding "line" -> "line_number".
-_BINDINGS_CACHE_FORMAT_VERSION = 3
+# `native_functions` entries). v2 introduced `python_module`; v3 added
+# package identity to metadata; v4 added the `registrations` section; v5
+# renamed binding "line" → "line_number".
+_BINDINGS_CACHE_FORMAT_VERSION = 5
 
 
-def _cache_metadata(source: str) -> dict:
+def _cache_metadata(source: str, manifest: ConventionManifest | None = None) -> dict:
     """Metadata every bindings-cache writer must emit; `_cache_valid` checks it."""
+    manifest = manifest or active_manifest()
     return {
         "source_path": source,
         "source_fingerprint": _source_fingerprint(source),
         "format_version": _BINDINGS_CACHE_FORMAT_VERSION,
+        "package": asdict(detect_package_identity(source, manifest.package)),
     }
 
 
@@ -133,20 +132,29 @@ def _cache_valid(cache: Path, source: str) -> bool:
         meta = data.get("metadata", {})
         if meta.get("format_version") != _BINDINGS_CACHE_FORMAT_VERSION:
             return False
+        if meta.get("package") != asdict(
+            detect_package_identity(source, active_manifest().package)
+        ):
+            return False
         return meta.get("source_fingerprint") == _source_fingerprint(source)
     except Exception:
         return False
 
 
-def _parse_native_functions(source: str) -> tuple[dict, dict]:
-    """Parse native_functions.yaml and derivatives.yaml."""
+def _parse_native_functions(
+    source: str, manifest: ConventionManifest | None = None
+) -> tuple[dict, dict]:
+    """Parse the manifest's YAML op/derivative sources; empty when undeclared."""
     import yaml
 
+    manifest = manifest or active_manifest()
     src = Path(source)
     functions, derivatives = {}, {}
 
-    nf_yaml = src / "aten/src/ATen/native/native_functions.yaml"
-    if nf_yaml.exists():
+    nf_yaml = (
+        src / manifest.native_functions_yaml if manifest.native_functions_yaml else None
+    )
+    if nf_yaml is not None and nf_yaml.exists():
         try:
             data = yaml.safe_load(nf_yaml.read_text())
             for entry in data or []:
@@ -193,8 +201,8 @@ def _parse_native_functions(source: str) -> tuple[dict, dict]:
         except Exception as e:
             log.warning(f"Failed to parse native_functions.yaml: {e}")
 
-    deriv_yaml = src / "tools/autograd/derivatives.yaml"
-    if deriv_yaml.exists():
+    deriv_yaml = src / manifest.derivatives_yaml if manifest.derivatives_yaml else None
+    if deriv_yaml is not None and deriv_yaml.exists():
         try:
             data = yaml.safe_load(deriv_yaml.read_text())
             for entry in data or []:
@@ -284,7 +292,7 @@ def _impls_from_extractor(target: str) -> list[dict]:
 
 
 def _find_implementations(
-    source: str, functions: dict
+    source: str, functions: dict, manifest: ConventionManifest | None = None
 ) -> tuple[dict[str, list[dict]], dict[str, str]]:
     """Find C++ implementations in source using configured search directories.
 
@@ -294,9 +302,10 @@ def _find_implementations(
     helper functions like `run_cudnn_SDP_fprop` that aren't YAML ops but still
     need a file-cohort bridge for test selection.
     """
+    manifest = manifest or active_manifest()
     src = Path(source)
 
-    search_dirs = [src / d for d in CPP_SEARCH_DIRS]
+    search_dirs = [src / d for d in manifest.cpp_search_dirs]
 
     targets = set()
     for f in functions.values():
@@ -402,19 +411,31 @@ def _fuzzy_find(name: str, data: dict[str, Any]) -> list[Any] | None:
     return None
 
 
-def _build_index(source: str) -> dict[str, Any]:
+def _build_index(
+    source: str, manifest: ConventionManifest | None = None
+) -> dict[str, Any]:
     """Build binding index from source."""
     from .analysis.binding_detector import BindingDetector
+    from .analysis.extractors import extract_registrations
 
+    manifest = manifest or active_manifest()
     log.info(f"Building index from {source}...")
     CACHE_DIR.mkdir(parents=True, exist_ok=True)
 
-    functions, derivatives = _parse_native_functions(source)
+    functions, derivatives = _parse_native_functions(source, manifest)
 
-    implementations, symbol_to_file = _find_implementations(source, functions)
+    implementations, symbol_to_file = _find_implementations(source, functions, manifest)
 
-    detector = BindingDetector()
+    detector = BindingDetector(
+        macro_aliases=manifest.cpp_macro_aliases, token_map=manifest.cpp_token_map
+    )
     graph = detector.detect_bindings_in_directory(source)
+
+    registrations = extract_registrations(source, manifest)
+    log.info(
+        f"Registrations: {len(registrations['records'])} records, "
+        f"{len(registrations['candidate_edges'])} candidate edges"
+    )
 
     data = {
         "bindings": [b.to_dict() for b in graph.bindings],
@@ -423,7 +444,8 @@ def _build_index(source: str) -> dict[str, Any]:
         "derivatives": derivatives,
         "native_implementations": implementations,
         "symbol_to_file": symbol_to_file,
-        "metadata": _cache_metadata(source),
+        "registrations": registrations,
+        "metadata": _cache_metadata(source, manifest),
     }
 
     cache = _cache_path(source)
@@ -482,6 +504,7 @@ def _load_from_json(path: str):
     _state.derivatives = data.get("derivatives", {})
     _state.native_implementations = data.get("native_implementations", {})
     _state.symbol_to_file = data.get("symbol_to_file", {})
+    _state.registrations = data.get("registrations", {})
 
     _build_indexes(_state)
 
@@ -594,11 +617,14 @@ def _init_python_modules(source: str):
         _state.alias_map = build_function_alias_map(_state.native_functions)
         log.info(f"Alias map: {len(_state.alias_map)} torch.<op> aliases")
 
-        analyzer = PythonAnalyzer(alias_map=_state.alias_map)
+        manifest = active_manifest()
+        analyzer = PythonAnalyzer(
+            alias_map=_state.alias_map,
+            package_roots=manifest.python_package_roots or None,
+        )
         src = Path(source)
 
-        # Use configured Python search directories
-        dirs_to_analyze = [src / d for d in PYTHON_SEARCH_DIRS]
+        dirs_to_analyze = [src / d for d in manifest.python_search_dirs]
 
         all_modules: dict[str, Any] = {}
         analyzed_count = 0
@@ -713,9 +739,11 @@ def _init_from_source(source: str):
         _state.derivatives = data.get("derivatives", {})
         _state.native_implementations = data.get("native_implementations", {})
         _state.symbol_to_file = data.get("symbol_to_file", {})
+        _state.registrations = data.get("registrations", {})
         _build_indexes(_state)
 
     _state.pytorch_source = str(src)
+    _state.package = detect_package_identity(str(src), active_manifest().package)
     _init_decomp_aliases(str(src))
     _init_backward_bridge()
     _init_dispatch_stubs(str(src))
@@ -761,7 +789,9 @@ def load_python_profiling(path: str) -> int:
     return len(data)
 
 
-_TEST_INFRA_CACHE_VERSION = 1
+# v2: mention vocabulary reseeded from native_functions + OpInfo names.
+# v3: vocabulary gains nn-Module PascalCase variants (`AvgPool2d`).
+_TEST_INFRA_CACHE_VERSION = 3
 
 
 def _save_test_infra_cache(path: Path) -> None:
@@ -825,14 +855,38 @@ def _init_test_infrastructure(source: str):
 
         log.info("Analyzing test infrastructure...")
 
-        # Bound the attr index by only recording mentions of names that
-        # could plausibly resolve to a known binding's API.
+        # OpInfo registry must exist before the scan: it feeds the mention
+        # vocabulary below.
+        opinfo_dirs = [
+            src / "torch/testing/_internal/opinfo",
+            src / "torch/testing/_internal/opinfo/definitions",
+        ]
+        for opinfo_dir in opinfo_dirs:
+            if opinfo_dir.exists():
+                for opinfo_file in opinfo_dir.glob("*.py"):
+                    _parse_opinfo_registry(str(opinfo_file))
+        op_db_main = src / "torch/testing/_internal/common_methods_invocations.py"
+        if op_db_main.exists():
+            _parse_opinfo_registry(str(op_db_main))
+
+        # Bound the attr index by only recording mentions of names that could
+        # plausibly resolve to an API: binding python_names, YAML op names, and
+        # OpInfo names/aliases. Seeding from bindings alone missed `cummax`,
+        # `gelu`, `avg_pool2d` — the ops CI selection needs most.
         interesting_attrs: set[str] = set()
         for py_name in _state.by_python_name:
             interesting_attrs.update(api_attr_variants(normalize_api(py_name)))
+        for name, entry in _state.native_functions.items():
+            interesting_attrs.update(api_attr_variants(entry.get("base_name") or name))
+        for op_name, entry in _state.opinfo_registry.items():
+            interesting_attrs.update(api_attr_variants(op_name))
+            for alias in entry.get("aliases", []):
+                interesting_attrs.update(api_attr_variants(alias))
+            if aten_name := entry.get("aten_name"):
+                interesting_attrs.update(api_attr_variants(aten_name))
 
         # Scan test directories
-        for test_dir in TEST_SEARCH_DIRS:
+        for test_dir in active_manifest().test_search_dirs:
             dir_path = src / test_dir
             if not dir_path.exists():
                 continue
@@ -948,7 +1002,7 @@ def _init_test_infrastructure(source: str):
                     log.debug(f"Error parsing {py_file.name}: {e}")
 
         # Index test utilities
-        for util_path in TEST_UTILITY_MODULES:
+        for util_path in active_manifest().test_utility_modules:
             full_path = src / util_path
             if full_path.exists():
                 _state.test_utilities[util_path] = {
@@ -956,20 +1010,6 @@ def _init_test_infrastructure(source: str):
                     "full_path": str(full_path),
                     "exists": True,
                 }
-
-        # Parse OpInfo registry - scan opinfo definition files plus the main
-        # op_db source (`common_methods_invocations.py`).
-        opinfo_dirs = [
-            src / "torch/testing/_internal/opinfo",
-            src / "torch/testing/_internal/opinfo/definitions",
-        ]
-        for opinfo_dir in opinfo_dirs:
-            if opinfo_dir.exists():
-                for opinfo_file in opinfo_dir.glob("*.py"):
-                    _parse_opinfo_registry(str(opinfo_file))
-        op_db_main = src / "torch/testing/_internal/common_methods_invocations.py"
-        if op_db_main.exists():
-            _parse_opinfo_registry(str(op_db_main))
 
         log.info(
             f"Test infrastructure: {len(_state.test_files)} files, "
@@ -1283,7 +1323,10 @@ def update_index(source: str, since: str, on_uncovered: str = "warn") -> dict:
         if _relpath(k.get("file_path", ""), prior_source) not in dirty
     ]
 
-    detector = BindingDetector()
+    detector = BindingDetector(
+        macro_aliases=active_manifest().cpp_macro_aliases,
+        token_map=active_manifest().cpp_token_map,
+    )
     src = Path(source)
     for rel in changed_cpp:
         full = src / rel
@@ -1313,6 +1356,11 @@ def update_index(source: str, since: str, on_uncovered: str = "warn") -> dict:
         "derivatives": derivatives,
         "native_implementations": implementations,
         "symbol_to_file": symbol_to_file,
+        # Python files are not rescanned on incremental update; carry the
+        # baseline's registration records forward.
+        "registrations": prior.get(
+            "registrations", {"records": [], "candidate_edges": []}
+        ),
         "metadata": {
             **_cache_metadata(source),
             "updated_since": since,
@@ -1510,6 +1558,9 @@ def build_index(source: str, wait_for_cpp: bool = True) -> dict:
         cg_functions = len(_state.cpp_extractor.function_locations)
 
     return {
+        "package": str(_state.package),
+        "registration_records": len(_state.registrations.get("records", [])),
+        "candidate_edges": len(_state.registrations.get("candidate_edges", [])),
         "bindings": len(_state.bindings),
         "cuda_kernels": len(_state.cuda_kernels),
         "native_functions": len(_state.native_functions),

--- a/src/torchtalk/indexer.py
+++ b/src/torchtalk/indexer.py
@@ -13,13 +13,19 @@ from typing import Any
 
 from .analysis.helpers import fuzzy_distance_limit, levenshtein_distance, truncate
 from .analysis.patterns import (
+    has_binding_patterns as _has_binding_patterns,
+)
+from .analysis.patterns import (
     has_test_patterns as _has_test_patterns,
 )
 from .analysis.patterns import is_vendor_path
 from .analysis.patterns import (
     should_exclude as _should_exclude,
 )
-from .config import CACHE_DIR, cache_paths, resolve_pytorch_source, source_hash
+from .analysis.patterns import (
+    should_include_dir as _should_include_dir,
+)
+from .config import CACHE_DIR, cache_paths, resolve_source
 from .harness import ConventionManifest, active_manifest
 from .symbols import PackageIdentity, content_fingerprint, detect_package_identity
 
@@ -85,23 +91,28 @@ def _source_fingerprint(source: str) -> str:
 
     Git checkouts get a content fingerprint (HEAD tree + dirty diff), so
     commits, pulls, and uncommitted edits all invalidate caches. Non-git
-    checkouts fall back to mtime/size of version files.
+    checkouts fall back to a coarse tree signal (file count + newest mtime
+    across the manifest's search dirs) so edits still invalidate; version
+    files alone would fingerprint every content state identically.
     """
     fp = content_fingerprint(source) if source else None
     if fp:
         return fp
     src = Path(source)
-    files = [
-        src / "version.txt",
-        src / "torch/version.py",
-        src / ".git/HEAD",
-    ]
-    parts = []
-    for f in files:
-        if f.exists():
-            s = f.stat()
-            parts.append(f"{f.name}:{s.st_mtime}:{s.st_size}")
-    return hashlib.md5("|".join(parts).encode()).hexdigest()[:16]
+    manifest = active_manifest()
+    newest, count = 0.0, 0
+    for d in sorted({*manifest.cpp_search_dirs, *manifest.python_search_dirs}):
+        root = src / d
+        if not root.exists():
+            continue
+        for p in root.rglob("*"):
+            try:
+                if p.is_file():
+                    count += 1
+                    newest = max(newest, p.stat().st_mtime)
+            except OSError:
+                continue
+    return hashlib.md5(f"tree:{count}:{newest}".encode()).hexdigest()[:16]
 
 
 # Bump when the bindings-cache schema changes (e.g. a new field added to
@@ -331,7 +342,7 @@ def _find_implementations(
             file_str = str(cpp_file)
 
             # Apply exclusion patterns
-            if _should_exclude(file_str):
+            if _should_exclude(file_str, manifest.exclude_patterns):
                 continue
 
             try:
@@ -427,7 +438,11 @@ def _build_index(
     implementations, symbol_to_file = _find_implementations(source, functions, manifest)
 
     detector = BindingDetector(
-        macro_aliases=manifest.cpp_macro_aliases, token_map=manifest.cpp_token_map
+        macro_aliases=manifest.cpp_macro_aliases,
+        token_map=manifest.cpp_token_map,
+        search_dirs=manifest.cpp_search_dirs,
+        exclude_patterns=manifest.exclude_patterns,
+        registration_macros=manifest.registration_macros,
     )
     graph = detector.detect_bindings_in_directory(source)
 
@@ -526,7 +541,7 @@ def _init_cpp_call_graph(source: str):
             return
 
         cg_cache_dir = CACHE_DIR / "call_graph"
-        cache_key = f"pytorch_callgraph_parallel_{source_hash(source)}"
+        cache_key = cache_paths(source)["callgraph"].stem
 
         extractor = CppCallGraphExtractor(cache_dir=cg_cache_dir)
         if extractor.load_cache(
@@ -542,11 +557,17 @@ def _init_cpp_call_graph(source: str):
         # Build in background
         import threading
 
+        manifest = active_manifest()
+
         def build():
             global _state
             try:
                 ext = CppCallGraphExtractor(cache_dir=cg_cache_dir)
-                ext.extract_from_pytorch_parallel(source)
+                ext.extract_from_pytorch_parallel(
+                    source,
+                    include_dirs=list(manifest.cpp_search_dirs),
+                    exclude_patterns=manifest.exclude_patterns,
+                )
                 ext.save_cache(cache_key, fingerprint=_source_fingerprint(source))
                 _state.cpp_extractor = ext
                 log.info(
@@ -886,10 +907,18 @@ def _init_test_infrastructure(source: str):
                 interesting_attrs.update(api_attr_variants(aten_name))
 
         # Scan test directories
-        for test_dir in active_manifest().test_search_dirs:
+        manifest = active_manifest()
+        for test_dir in manifest.test_search_dirs:
             dir_path = src / test_dir
             if not dir_path.exists():
                 continue
+
+            # Standalone test dirs (outside the import package) are indexed
+            # inclusively; package-internal dirs (e.g. torch/testing) hold
+            # utilities, so only content-matching files are indexed.
+            is_main_test_dir = (
+                test_dir.split("/")[0] not in manifest.python_package_roots
+            )
 
             for py_file in dir_path.rglob("*.py"):
                 file_str = str(py_file)
@@ -901,12 +930,9 @@ def _init_test_infrastructure(source: str):
                 try:
                     content = py_file.read_text(encoding="utf-8", errors="replace")
 
-                    # For test/ directory, be inclusive - index all .py files
-                    # For torch/testing/, use pattern filtering
-                    is_main_test_dir = (
-                        "/test/" in file_str and "/testing/" not in file_str
-                    )
-                    if not is_main_test_dir and not _has_test_patterns(content):
+                    if not is_main_test_dir and not _has_test_patterns(
+                        content, manifest.test_content_patterns
+                    ):
                         continue
 
                     # Parse AST to extract test classes and functions
@@ -1002,7 +1028,7 @@ def _init_test_infrastructure(source: str):
                     log.debug(f"Error parsing {py_file.name}: {e}")
 
         # Index test utilities
-        for util_path in active_manifest().test_utility_modules:
+        for util_path in manifest.test_utility_modules:
             full_path = src / util_path
             if full_path.exists():
                 _state.test_utilities[util_path] = {
@@ -1231,13 +1257,13 @@ def _parse_opinfo_registry(opinfo_path: str):
         log.debug(f"Failed to read OpInfo file {opinfo_path}: {e}")
 
 
-def _auto_detect_pytorch() -> str | None:
-    """Auto-detect PyTorch source using 3-level resolution.
+def _auto_detect_source() -> str | None:
+    """Auto-detect the active harness's source using 3-level resolution.
 
-    Priority: PYTORCH_SOURCE env var > config.toml > None
+    Priority: env var > config.toml > None.
     CLI flag is handled upstream in run_server().
     """
-    return resolve_pytorch_source()
+    return resolve_source()
 
 
 def update_index(source: str, since: str, on_uncovered: str = "warn") -> dict:
@@ -1259,6 +1285,12 @@ def update_index(source: str, since: str, on_uncovered: str = "warn") -> dict:
     from .snapshots import _relpath, _snapshot_dir, read_manifest
 
     manifest = read_manifest(since)
+    active = active_manifest()
+    if manifest.package and manifest.package != active.package:
+        raise ValueError(
+            f"Snapshot '{since}' was built by the '{manifest.package}' harness "
+            f"but '{active.package}' is active. Pass --harness {manifest.package}."
+        )
     if not manifest.git_commit:
         raise ValueError(
             f"Snapshot '{since}' has no git_commit; cannot diff against HEAD"
@@ -1266,6 +1298,16 @@ def update_index(source: str, since: str, on_uncovered: str = "warn") -> dict:
 
     snap_dir = _snapshot_dir(since)
     prior = json.loads((snap_dir / "bindings.json").read_text())
+
+    # Prior rows are carried forward verbatim; an older payload schema would
+    # produce a mixed-format cache that _cache_valid then accepts.
+    prior_version = prior.get("metadata", {}).get("format_version")
+    if prior_version != _BINDINGS_CACHE_FORMAT_VERSION:
+        raise ValueError(
+            f"Snapshot '{since}' bindings use cache format v{prior_version}; "
+            f"current is v{_BINDINGS_CACHE_FORMAT_VERSION}. Run 'torchtalk "
+            "index build' and save a fresh snapshot."
+        )
 
     try:
         diff_out = subprocess.run(
@@ -1288,8 +1330,7 @@ def update_index(source: str, since: str, on_uncovered: str = "warn") -> dict:
     cpp_exts = (".cpp", ".cc", ".cxx", ".cu", ".cuh")
     header_exts = (".h", ".hpp", ".hxx", ".hh", ".inc")
     yaml_files = {
-        "aten/src/ATen/native/native_functions.yaml",
-        "tools/autograd/derivatives.yaml",
+        p for p in (active.native_functions_yaml, active.derivatives_yaml) if p
     }
 
     changed_cpp: set[str] = set()
@@ -1324,17 +1365,29 @@ def update_index(source: str, since: str, on_uncovered: str = "warn") -> dict:
     ]
 
     detector = BindingDetector(
-        macro_aliases=active_manifest().cpp_macro_aliases,
-        token_map=active_manifest().cpp_token_map,
+        macro_aliases=active.cpp_macro_aliases,
+        token_map=active.cpp_token_map,
     )
     src = Path(source)
+    # Same harness boundary as the full build: search dirs, exclusion
+    # patterns, and the binding-pattern prefilter must all match
+    # detect_bindings_in_directory, or incremental results diverge.
+    bounds = tuple(d.rstrip("/") + "/" for d in active.cpp_search_dirs)
     for rel in changed_cpp:
+        if bounds and not rel.startswith(bounds):
+            continue
+        # Exclusion runs on the repo-relative path: patterns describe repo
+        # shapes, and the checkout's own directory name must not match them.
+        if _should_exclude(rel, active.exclude_patterns):
+            continue
         full = src / rel
         if not full.exists():
             continue
         try:
             content = full.read_text(errors="ignore")
         except OSError:
+            continue
+        if not _has_binding_patterns(content, active.registration_macros):
             continue
         g = detector.detect_bindings(str(full), content)
         new_bindings.extend(b.to_dict() for b in g.bindings)
@@ -1476,7 +1529,7 @@ def _update_call_graph(
         return {"skipped": "baseline snapshot has no call graph"}
 
     cg_cache_dir = CACHE_DIR / "call_graph"
-    cache_key = f"pytorch_callgraph_parallel_{source_hash(source)}"
+    cache_key = cache_paths(source)["callgraph"].stem
 
     extractor = CppCallGraphExtractor(cache_dir=cg_cache_dir)
     if not extractor.load_from_path(snap_cg):
@@ -1510,9 +1563,15 @@ def _update_call_graph(
         widened_net = widened - tus_to_reparse
         tus_to_reparse |= widened
 
+    # Same harness boundary as the full call-graph build.
+    active = active_manifest()
     entries: list[tuple[str, list[str]]] = []
     for rel in tus_to_reparse:
         full = str(src / rel)
+        if not _should_include_dir(full, list(active.cpp_search_dirs)):
+            continue
+        if _should_exclude(full, active.exclude_patterns):
+            continue
         entry = cc_index.get(full)
         if entry is None:
             continue

--- a/src/torchtalk/server.py
+++ b/src/torchtalk/server.py
@@ -64,6 +64,13 @@ async def get_status() -> str:
         )
     if _state.derivatives:
         md.bold("Derivatives", f"{len(_state.derivatives):,} formulas")
+    if _state.registrations:
+        md.bold(
+            "Registrations",
+            f"{len(_state.registrations.get('records', [])):,} records, "
+            f"{len(_state.registrations.get('candidate_edges', [])):,} "
+            "candidate edges",
+        )
     md.blank()
 
     md.h3("C++ Call Graph")

--- a/src/torchtalk/server.py
+++ b/src/torchtalk/server.py
@@ -10,7 +10,7 @@ from mcp.server.fastmcp import FastMCP
 
 from .formatting import create_formatter
 from .indexer import (
-    _auto_detect_pytorch,
+    _auto_detect_source,
     _init_from_source,
     _load_from_json,
     _state,
@@ -311,7 +311,7 @@ def run_server(
     error via `_ensure_loaded` until the data is ready."""
     import threading
 
-    source = pytorch_source or _auto_detect_pytorch()
+    source = pytorch_source or _auto_detect_source()
 
     def _bg_init():
         try:

--- a/src/torchtalk/snapshots.py
+++ b/src/torchtalk/snapshots.py
@@ -26,6 +26,7 @@ from pathlib import Path
 from typing import Any
 
 from .config import CACHE_DIR, cache_paths, resolve_pytorch_source
+from .symbols import content_fingerprint as _content_fingerprint
 
 SNAPSHOTS_DIR = CACHE_DIR / "snapshots"
 MANIFEST_NAME = "manifest.json"
@@ -142,40 +143,6 @@ def _git_commit(source: str) -> str | None:
         subprocess.TimeoutExpired,
     ):
         return None
-
-
-def _content_fingerprint(source: str) -> str | None:
-    """Merkle-style hash over HEAD tree + any uncommitted diff.
-
-    Uses git's own tree hash (a content-addressed Merkle over all tracked files)
-    combined with a hash of `git diff HEAD` to cover dirty trees. Two checkouts
-    with identical content produce the same fingerprint regardless of path.
-    Returns None when source is not a git working tree.
-    """
-    try:
-        tree = subprocess.run(
-            ["git", "-C", source, "rev-parse", "HEAD^{tree}"],
-            capture_output=True,
-            text=True,
-            check=True,
-            timeout=5,
-        ).stdout.strip()
-        diff = subprocess.run(
-            ["git", "-C", source, "diff", "HEAD"],
-            capture_output=True,
-            check=True,
-            timeout=15,
-        ).stdout
-    except (
-        subprocess.CalledProcessError,
-        FileNotFoundError,
-        subprocess.TimeoutExpired,
-    ):
-        return None
-
-    h = hashlib.blake2b(tree.encode(), digest_size=16)
-    h.update(diff)
-    return h.hexdigest()
 
 
 def _is_ancestor(source: str, ancestor: str, descendant: str) -> bool:

--- a/src/torchtalk/snapshots.py
+++ b/src/torchtalk/snapshots.py
@@ -25,12 +25,13 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from .config import CACHE_DIR, cache_paths, resolve_pytorch_source
+from .config import CACHE_DIR, cache_paths, resolve_source, source_hash
+from .harness import active_manifest
 from .symbols import content_fingerprint as _content_fingerprint
 
 SNAPSHOTS_DIR = CACHE_DIR / "snapshots"
 MANIFEST_NAME = "manifest.json"
-SCHEMA_VERSION = 2
+SCHEMA_VERSION = 3
 
 _NAME_COMPONENT_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
 _NAME_MAX_COMPONENTS = 3
@@ -66,6 +67,8 @@ class SnapshotManifest:
     callgraph_size: int = 0
     callgraph_sha256: str = ""
     content_fingerprint: str | None = None
+    # Harness package that built the snapshotted cache; "" on pre-v3 snapshots.
+    package: str = ""
     schema_version: int = SCHEMA_VERSION
 
 
@@ -182,6 +185,9 @@ def _migrate(data: dict[str, Any]) -> dict[str, Any]:
     if data["schema_version"] < 2:
         data.setdefault("content_fingerprint", None)
         data["schema_version"] = 2
+    if data["schema_version"] < 3:
+        data.setdefault("package", "")
+        data["schema_version"] = 3
     return data
 
 
@@ -247,11 +253,16 @@ def find_nearest_snapshot(source: str | None = None) -> SnapshotManifest | None:
     > most recent ancestor commit. Returns None if nothing matches or source is
     not a git working tree.
     """
-    source = source or resolve_pytorch_source()
+    source = source or resolve_source()
     if not source:
         return None
 
-    candidates = list_snapshots()
+    # Cross-harness snapshots would fail load_snapshot's package guard;
+    # pre-v3 snapshots (package "") are kept as candidates.
+    active_package = active_manifest().package
+    candidates = [
+        m for m in list_snapshots() if not m.package or m.package == active_package
+    ]
     content_fp = _content_fingerprint(source)
     if content_fp:
         for m in candidates:
@@ -279,7 +290,7 @@ def save_snapshot(name: str) -> SnapshotManifest:
     """
     _validate_name(name)
 
-    source = resolve_pytorch_source()
+    source = resolve_source()
     if not source:
         raise SnapshotError("No PyTorch source configured. Run 'torchtalk init' first.")
 
@@ -316,18 +327,18 @@ def save_snapshot(name: str) -> SnapshotManifest:
             callgraph_size = cg_tmp.stat().st_size
             callgraph_sha256 = _hash_file(cg_tmp)
 
-        fingerprint = paths["bindings"].stem.removeprefix("bindings_")
         manifest = SnapshotManifest(
             name=name,
             created=datetime.now(timezone.utc).isoformat(),
             pytorch_source=source,
-            source_fingerprint=fingerprint,
+            source_fingerprint=source_hash(source),
             git_commit=_git_commit(source),
             bindings_size=bindings_size,
             bindings_sha256=bindings_sha256,
             callgraph_size=callgraph_size,
             callgraph_sha256=callgraph_sha256,
             content_fingerprint=_content_fingerprint(source),
+            package=active_manifest().package,
         )
         _atomic_write_text(
             tmp_path / MANIFEST_NAME, json.dumps(asdict(manifest), indent=2)
@@ -360,9 +371,16 @@ def load_snapshot(name: str, force: bool = False) -> SnapshotManifest:
     ):
         raise SnapshotCorruptError(f"Snapshot '{name}' callgraph.json failed checksum")
 
-    source = resolve_pytorch_source() or manifest.pytorch_source
+    active_package = active_manifest().package
+    if manifest.package and manifest.package != active_package:
+        raise SnapshotError(
+            f"Snapshot '{name}' was built by the '{manifest.package}' harness "
+            f"but '{active_package}' is active. Pass --harness {manifest.package}."
+        )
+
+    source = resolve_source() or manifest.pytorch_source
     paths = cache_paths(source)
-    current_fp = paths["bindings"].stem.removeprefix("bindings_")
+    current_fp = source_hash(source)
     current_content_fp = _content_fingerprint(source)
 
     path_match = current_fp == manifest.source_fingerprint

--- a/src/torchtalk/symbols.py
+++ b/src/torchtalk/symbols.py
@@ -1,0 +1,120 @@
+"""Package-qualified symbol identity for cross-repo graph merging.
+
+Symbol IDs follow ``<package>@<revision>/<symbol>``, e.g.
+``pytorch@a1b2c3d4e5f6/at::native::add``. Revision is the short git HEAD
+sha of the source checkout, falling back to a version string.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+UNKNOWN_REVISION = "unknown"
+
+_HEX_SHA_RE = re.compile(r"[0-9a-f]{40,64}")
+_VERSION_RE = re.compile(r"__version__\s*=\s*['\"]([^'\"]+)['\"]")
+
+
+@dataclass(frozen=True)
+class PackageIdentity:
+    """A source package pinned to a revision (git sha or version string)."""
+
+    name: str
+    revision: str
+
+    def __str__(self) -> str:
+        return f"{self.name}@{self.revision}"
+
+
+def make_symbol_id(package: PackageIdentity, symbol: str) -> str:
+    """Build a globally unique symbol ID: ``<package>@<revision>/<symbol>``."""
+    return f"{package}/{symbol}"
+
+
+def parse_symbol_id(symbol_id: str) -> tuple[PackageIdentity, str]:
+    """Split a symbol ID into (PackageIdentity, symbol); ValueError if malformed."""
+    head, slash, symbol = symbol_id.partition("/")
+    name, at, revision = head.partition("@")
+    if not (slash and at and name and revision and symbol):
+        raise ValueError(f"Malformed symbol ID: {symbol_id!r}")
+    return PackageIdentity(name, revision), symbol
+
+
+def detect_package_identity(source: str | Path, name: str) -> PackageIdentity:
+    """Derive package identity from a source checkout."""
+    src = Path(source)
+    revision = _git_head_sha(src) or _version_string(src) or UNKNOWN_REVISION
+    return PackageIdentity(name, revision)
+
+
+def content_fingerprint(source: str | Path) -> str | None:
+    """Merkle-style hash over HEAD tree + any uncommitted diff.
+
+    Uses git's own tree hash (a content-addressed Merkle over all tracked files)
+    combined with a hash of `git diff HEAD` to cover dirty trees. Two checkouts
+    with identical content produce the same fingerprint regardless of path.
+    Returns None when source is not a git working tree.
+    """
+    try:
+        tree = subprocess.run(
+            ["git", "-C", str(source), "rev-parse", "HEAD^{tree}"],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=5,
+        ).stdout.strip()
+        diff = subprocess.run(
+            ["git", "-C", str(source), "diff", "HEAD"],
+            capture_output=True,
+            check=True,
+            timeout=15,
+        ).stdout
+    except (
+        subprocess.CalledProcessError,
+        FileNotFoundError,
+        subprocess.TimeoutExpired,
+    ):
+        return None
+
+    h = hashlib.blake2b(tree.encode(), digest_size=16)
+    h.update(diff)
+    return h.hexdigest()
+
+
+def _git_head_sha(src: Path) -> str | None:
+    """Short HEAD sha via git, falling back to reading .git/HEAD directly."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(src), "rev-parse", "--short=12", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout.strip()
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+    head = src / ".git" / "HEAD"
+    if head.is_file():
+        text = head.read_text(errors="ignore").strip()
+        if _HEX_SHA_RE.fullmatch(text):
+            return text[:12]
+    return None
+
+
+def _version_string(src: Path) -> str | None:
+    """Version from version.txt or a top-level package's version.py."""
+    version_txt = src / "version.txt"
+    if version_txt.is_file():
+        version = version_txt.read_text(errors="ignore").strip()
+        if version:
+            return version
+    for version_py in sorted(src.glob("*/version.py")):
+        match = _VERSION_RE.search(version_py.read_text(errors="ignore"))
+        if match:
+            return match.group(1)
+    return None

--- a/src/torchtalk/tools/affected.py
+++ b/src/torchtalk/tools/affected.py
@@ -117,7 +117,7 @@ async def _do_affected(funcs: str, depth: int = 3) -> str:
             else:
                 node_ids.append(f"{file}::{cls}")
 
-    md.h3(f"Test runs ({len(runs)} files)")
+    md.h3(f"Test runs ({len(runs) + len(opinfo_runs)} selections)")
     for nid in node_ids:
         md.item(f"`{nid}`")
     for orun in opinfo_runs:

--- a/src/torchtalk/tools/affected.py
+++ b/src/torchtalk/tools/affected.py
@@ -58,6 +58,7 @@ async def _do_affected(funcs: str, depth: int = 3) -> str:
         bindings_by_file=_state.bindings_by_file or None,
         ops_by_file=_state.ops_by_file or None,
         symbol_to_file=_state.symbol_to_file or None,
+        test_functions=_state.test_functions or None,
         depth=depth,
     )
 
@@ -94,21 +95,41 @@ async def _do_affected(funcs: str, depth: int = 3) -> str:
     md.blank()
 
     runs = result["test_runs"]
-    if not runs:
+    opinfo_runs = result.get("opinfo_runs", [])
+    if not runs and not opinfo_runs:
         md.text("*No matching test runs found.*")
         return md.build()
 
-    md.h3(f"Test runs ({len(runs)} files)")
-    for tr in runs[:30]:
+    # Pytest node IDs: file::Class, refined to ::Class::function where the
+    # test_functions join found exact matches.
+    function_hits = result.get("function_hits", {})
+    node_ids: list[str] = []
+    for tr in runs:
+        file = tr["file"]
         classes = tr["included_classes"]
-        if classes:
-            md.item(f"`{tr['file']}` — {', '.join(classes[:5])}")
-            if len(classes) > 5:
-                md.item(f"...and {len(classes) - 5} more", 1)
-        else:
-            md.item(f"`{tr['file']}` *(whole file)*")
+        if not classes:
+            node_ids.append(file)
+            continue
+        for cls in classes:
+            funcs_in_cls = function_hits.get(file, {}).get(cls, [])
+            if funcs_in_cls:
+                node_ids.extend(f"{file}::{cls}::{fn}" for fn in funcs_in_cls)
+            else:
+                node_ids.append(f"{file}::{cls}")
 
-    if len(runs) > 30:
-        md.text(f"\n*Showing 30 of {len(runs)} files.*")
+    md.h3(f"Test runs ({len(runs)} files)")
+    for nid in node_ids:
+        md.item(f"`{nid}`")
+    for orun in opinfo_runs:
+        md.item(f'`{" ".join(orun["files"])} -k "{orun["k"]}"`')
+
+    lines = []
+    if node_ids:
+        lines.append("pytest " + " ".join(node_ids))
+    lines.extend(
+        f'pytest {" ".join(orun["files"])} -k "{orun["k"]}"' for orun in opinfo_runs
+    )
+    md.blank()
+    md.codeblock("\n".join(lines))
 
     return md.build()

--- a/tests/test_affected.py
+++ b/tests/test_affected.py
@@ -9,6 +9,7 @@ import pytest
 
 from torchtalk.analysis.affected import (
     _api_to_source_paths,
+    _bindings_for,
     _class_matches_api,
     _filename_family,
     _tests_mentioning_apis,
@@ -169,18 +170,15 @@ class TestAffectedTests:
             opinfo_test_files=opinfo_test_files,
             depth=1,
         )
-        runs_by_file = {
-            tr["file"]: tr["included_classes"] for tr in result["test_runs"]
-        }
-        assert runs_by_file == {
-            "test/test_ops.py": [],
-            "test/test_meta.py": [],
-        }
+        # v2: OpInfo expansion is a -k run, not whole-file blankets.
+        assert result["test_runs"] == []
+        assert result["opinfo_runs"] == [
+            {"files": ["test/test_ops.py", "test/test_meta.py"], "k": "foo"}
+        ]
 
     def test_no_opinfo_match_falls_back_to_opinfo_files(self, extractor):
         # API resolved but not in OpInfo and no test class matches → catch-all
-        # adds OpInfo whole-file runs (test_ops.py / test_meta.py exercise
-        # ops via @ops(op_db) parametrization).
+        # emits a -k-bounded OpInfo run instead of whole files.
         by_cpp_name = {"foo_kernel": [{"python_name": "aten.foo"}]}
         opinfo_registry = {"bar": {}}  # foo not registered
         opinfo_test_files = {"test/test_ops.py"}
@@ -195,7 +193,8 @@ class TestAffectedTests:
             opinfo_test_files=opinfo_test_files,
             depth=1,
         )
-        assert {tr["file"] for tr in result["test_runs"]} == {"test/test_ops.py"}
+        assert result["test_runs"] == []
+        assert result["opinfo_runs"] == [{"files": ["test/test_ops.py"], "k": "foo"}]
 
     def test_opinfo_alias_match_expands_files(self, extractor):
         # API "conv2d" not in opinfo_registry directly, but is in alias_map
@@ -218,8 +217,11 @@ class TestAffectedTests:
             opinfo_test_files=opinfo_test_files,
             depth=1,
         )
-        files = {tr["file"] for tr in result["test_runs"]}
-        assert files == {"test/test_ops.py", "test/test_meta.py"}
+        assert result["test_runs"] == []
+        # alias key `conv2d` resolves to the canonical OpInfo op name
+        (orun,) = result["opinfo_runs"]
+        assert orun["files"] == ["test/test_ops.py", "test/test_meta.py"]
+        assert orun["k"] == "conv2d"
 
     def test_decomp_alias_expansion_reaches_user_facing_test_class(self, extractor):
         # Binding lands on `convolution_overrideable` (no TestConvolutionOverrideable
@@ -379,29 +381,6 @@ class TestAffectedTests:
         )
         assert "cudnn_convolution" in result["python_apis"]
         assert {tr["file"] for tr in result["test_runs"]} == {"test/test_conv.py"}
-
-    def test_catchall_opinfo_when_no_test_class_matches(self, extractor):
-        # API resolved (convolution_overrideable) but no test class by name and
-        # not in OpInfo → fall back to OpInfo whole-file runs.
-        by_cpp_name = {
-            "convolution_overrideable": [
-                {
-                    "python_name": "aten.convolution_overrideable",
-                    "cpp_name": "convolution_overrideable",
-                }
-            ]
-        }
-        result = affected_tests(
-            funcs=["at::native::convolution_overrideable"],
-            cpp_extractor=extractor,
-            by_cpp_name=by_cpp_name,
-            test_classes={},  # no class matches
-            test_files={"test/test_ops.py": {}, "test/test_meta.py": {}},
-            opinfo_test_files={"test/test_ops.py", "test/test_meta.py"},
-            depth=1,
-        )
-        files = {tr["file"] for tr in result["test_runs"]}
-        assert files == {"test/test_ops.py", "test/test_meta.py"}
 
     def test_catchall_skipped_when_test_class_already_matched(self, extractor):
         # If class-name match already produced a hit, don't add catch-all noise.
@@ -1258,15 +1237,20 @@ class TestMentionCapUnbounded:
 
 class TestApiAttrVariants:
     def test_includes_self_and_in_place_pair(self):
-        assert api_attr_variants("copy") == {"copy", "copy_"}
-        assert api_attr_variants("copy_") == {"copy", "copy_"}
+        assert api_attr_variants("copy") == {"copy", "copy_", "Copy"}
+        assert api_attr_variants("copy_") == {"copy", "copy_", "Copy"}
 
     def test_dotted_api_includes_leaf(self):
         assert api_attr_variants("masked.sum") == {
             "masked.sum",
             "sum",
             "sum_",
+            "Sum",
         }
+
+    def test_nn_module_pascal_variant(self):
+        assert "AvgPool2d" in api_attr_variants("avg_pool2d")
+        assert "Linear" in api_attr_variants("linear")
 
     def test_drops_empty_strings(self):
         # rstrip("_") on a bare "_" produces "" — must not pollute the set.
@@ -1668,3 +1652,219 @@ class TestAffectedDepthClamp:
         assert captured["depth"] == 1
         asyncio.run(_do_affected("foo", depth=99))
         assert captured["depth"] == 5
+
+
+class TestBindingsForCandidateOrder:
+    def test_out_suffix_op_preferred_over_impl_symbol(self):
+        # `cummax_out` exists as an impl symbol; its stripped stem `cummax`
+        # is the real YAML op — the op must win.
+        _, api_sources = _bindings_for(
+            {"at::native::cummax_out"},
+            by_cpp_name={},
+            native_functions={"cummax": {}},
+            native_implementations={"cummax_out": [{"function_name": "cummax_out"}]},
+        )
+        assert "cummax" in api_sources
+        assert "cummax_out" not in api_sources
+
+    def test_bare_yaml_op_still_wins_directly(self):
+        _, api_sources = _bindings_for(
+            {"gelu"},
+            by_cpp_name={},
+            native_functions={"gelu": {}},
+            native_implementations={},
+        )
+        assert "gelu" in api_sources
+
+
+class TestOpInfoRunGating:
+    @pytest.fixture
+    def extractor(self):
+        ext = MagicMock()
+        ext.get_callers.return_value = []
+        return ext
+
+    def _run(self, extractor, **kw):
+        return affected_tests(
+            funcs=["foo_kernel"],
+            cpp_extractor=extractor,
+            by_cpp_name={"foo_kernel": [{"python_name": "aten.foo"}]},
+            test_classes={},
+            test_files={"test/test_ops.py": {}},
+            opinfo_test_files={"test/test_ops.py"},
+            depth=1,
+            **kw,
+        )
+
+    def test_dotted_opinfo_key_reachable_via_leaf(self, extractor):
+        result = self._run(
+            extractor,
+            opinfo_registry={"torch.ops.aten.foo": {"name": "torch.ops.aten.foo"}},
+        )
+        (orun,) = result["opinfo_runs"]
+        assert orun["k"] == "torch_ops_aten_foo"
+
+    def test_fuzzy_only_apis_never_trigger_opinfo_runs(self, extractor):
+        # `max` arrives via cohort (fuzzy) — the old blanket trigger.
+        result = affected_tests(
+            funcs=["some_helper"],
+            cpp_extractor=extractor,
+            by_cpp_name={"some_helper": [{"python_name": None, "file_path": "/k.cu"}]},
+            bindings_by_file={
+                "/k.cu": [
+                    {"python_name": "max", "file_path": "/k.cu"},
+                    {"python_name": "min", "file_path": "/k.cu"},
+                ]
+            },
+            test_classes={},
+            test_files={"test/test_ops.py": {}},
+            opinfo_registry={"max": {}, "min": {}},
+            opinfo_test_files={"test/test_ops.py"},
+            depth=1,
+        )
+        assert result["opinfo_runs"] == []
+        assert result["test_runs"] == []
+
+
+class TestGradientsRun:
+    @pytest.fixture
+    def extractor(self):
+        ext = MagicMock()
+        ext.get_callers.return_value = []
+        return ext
+
+    def test_backward_input_adds_bwd_gradients_k_run(self, extractor):
+        result = affected_tests(
+            funcs=["gelu_backward"],
+            cpp_extractor=extractor,
+            by_cpp_name={"gelu_backward": [{"python_name": "aten.gelu_backward"}]},
+            test_classes={},
+            test_files={"test/test_ops_gradients.py": {}},
+            backward_to_forward={"gelu_backward": ["gelu"]},
+            depth=1,
+        )
+        assert {"files": ["test/test_ops_gradients.py"], "k": "gelu"} in result[
+            "opinfo_runs"
+        ]
+
+
+class TestFunctionLevelHits:
+    @pytest.fixture
+    def extractor(self):
+        ext = MagicMock()
+        ext.get_callers.return_value = []
+        return ext
+
+    def test_precise_api_joins_to_function_rows(self, extractor):
+        result = affected_tests(
+            funcs=["cummax"],
+            cpp_extractor=extractor,
+            by_cpp_name={"cummax": [{"python_name": "aten.cummax"}]},
+            test_classes={
+                "TestCummax": [{"file": "test/test_torch.py", "is_test_class": True}]
+            },
+            test_files={"test/test_torch.py": {}},
+            test_functions={
+                "test_cummax_cummin": [
+                    {
+                        "name": "test_cummax_cummin",
+                        "class": "TestCummax",
+                        "file": "test/test_torch.py",
+                    }
+                ],
+                "test_unrelated": [
+                    {
+                        "name": "test_unrelated",
+                        "class": "TestCummax",
+                        "file": "test/test_torch.py",
+                    }
+                ],
+            },
+            depth=1,
+        )
+        assert result["function_hits"] == {
+            "test/test_torch.py": {"TestCummax": ["test_cummax_cummin"]}
+        }
+
+
+class TestPytestOutputRendering:
+    def test_node_ids_and_pytest_block(self, monkeypatch):
+        from unittest.mock import MagicMock
+
+        from torchtalk import indexer
+        from torchtalk.tools import affected as affected_tool
+
+        ext = MagicMock()
+        monkeypatch.setattr(indexer._state, "bindings", [{"x": 1}])
+        monkeypatch.setattr(indexer._state, "cpp_extractor", ext)
+
+        def fake_affected_tests(**kwargs):
+            return {
+                "callers_walked": 1,
+                "bindings_matched": [],
+                "python_apis": ["cummax"],
+                "api_sources": {"cummax": ["call_graph"]},
+                "api_tier": {"cummax": "precise"},
+                "test_runs": [
+                    {
+                        "file": "test/test_torch.py",
+                        "included_classes": ["TestTorchDeviceType"],
+                    }
+                ],
+                "opinfo_runs": [{"files": ["test/test_ops.py"], "k": "cummax"}],
+                "function_hits": {
+                    "test/test_torch.py": {
+                        "TestTorchDeviceType": ["test_cummax_cummin"]
+                    }
+                },
+            }
+
+        monkeypatch.setattr(affected_tool, "affected_tests", fake_affected_tests)
+        out = asyncio.run(_do_affected("cummax"))
+        assert "test/test_torch.py::TestTorchDeviceType::test_cummax_cummin" in out
+        assert 'test/test_ops.py -k "cummax"' in out
+        assert (
+            "pytest test/test_torch.py::TestTorchDeviceType::test_cummax_cummin" in out
+        )
+
+
+class TestStructuredImplCandidates:
+    @pytest.fixture
+    def extractor(self):
+        ext = MagicMock()
+        ext.get_callers.return_value = []
+        return ext
+
+    def test_structured_class_member_resolves_to_op(self, extractor):
+        _, api_sources = _bindings_for(
+            {"at::native::structured_avg_pool2d_backward_out_cuda::impl"},
+            by_cpp_name={},
+            native_functions={"avg_pool2d_backward": {}},
+        )
+        assert "avg_pool2d_backward" in api_sources
+
+    def test_non_structured_names_unaffected(self, extractor):
+        _, api_sources = _bindings_for(
+            {"at::native::plain_helper"},
+            by_cpp_name={},
+            native_functions={"avg_pool2d_backward": {}},
+        )
+        assert api_sources == {}
+
+
+class TestMentionCapCountsDistinctFiles:
+    def test_many_hits_in_few_files_kept(self):
+        # 60 raw hits concentrated in 2 files: specific-but-popular API
+        # (the avg_pool2d shape) must survive the cap.
+        attr_index = {
+            "avg_pool2d": [
+                {"file": f"test/f{i % 2}.py", "class": "TestPool", "function": "t"}
+                for i in range(60)
+            ],
+        }
+        test_files = {"test/f0.py": {}, "test/f1.py": {}}
+        result, contributing = _tests_mentioning_apis(
+            {"avg_pool2d"}, attr_index, test_files, per_api_cap=50
+        )
+        assert set(result) == {"test/f0.py", "test/f1.py"}
+        assert "avg_pool2d" in contributing

--- a/tests/test_binding_detector.py
+++ b/tests/test_binding_detector.py
@@ -221,6 +221,60 @@ class TestCudaDeviceFuncBinding:
         assert device_bindings == []
 
 
+class TestManifestMacroConfig:
+    """Primitive 1: macro-alias expansion + token substitution (vLLM shape)."""
+
+    def _detector(self):
+        return BindingDetector(
+            macro_aliases={"TORCH_LIBRARY_EXPAND": "TORCH_LIBRARY"},
+            token_map={"TORCH_EXTENSION_NAME": "_C"},
+        )
+
+    def test_macro_alias_expands_to_torch_library(self):
+        code = (
+            "TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {\n"
+            '  ops.def("paged_attention(Tensor q) -> Tensor");\n'
+            '  ops.impl("paged_attention", &paged_attention);\n'
+            "}\n"
+        )
+        graph = self._detector().detect_bindings("/x.cpp", code)
+        by_type = {b.binding_type: b for b in graph.bindings}
+        op = by_type[BindingType.TORCH_OP.value]
+        assert op.python_name == "_C.paged_attention"
+        assert op.namespace == "_C"
+        assert op.line_number == 2
+        impl = by_type[BindingType.TORCH_LIBRARY_IMPL.value]
+        assert impl.cpp_name == "paged_attention"
+
+    def test_token_map_resolves_pybind_module_name(self):
+        code = 'PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) { m.def("fwd", &fwd); }'
+        graph = self._detector().detect_bindings("/y.cpp", code)
+        assert graph.bindings[0].namespace == "_C"
+        assert "TORCH_EXTENSION_NAME" not in {b.namespace for b in graph.bindings}
+
+    def test_unconfigured_detector_is_unchanged(self):
+        code = (
+            'TORCH_LIBRARY(aten, m) { m.def("relu(Tensor self) -> Tensor"); }\n'
+            "TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {\n"
+            '  ops.def("paged_attention(Tensor q) -> Tensor");\n'
+            "}\n"
+        )
+        graph = BindingDetector().detect_bindings("/z.cpp", code)
+        names = {b.python_name for b in graph.bindings}
+        assert "aten.relu" in names
+        assert not any("paged_attention" in n for n in names)
+
+    def test_word_boundary_no_partial_token_hits(self):
+        code = (
+            "TORCH_LIBRARY_EXPANDED_THING(foo, m) {}\n"
+            "TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {\n"
+            '  ops.def("op_a(Tensor t) -> Tensor");\n'
+            "}\n"
+        )
+        graph = self._detector().detect_bindings("/w.cpp", code)
+        assert {b.namespace for b in graph.bindings if b.namespace} == {"_C"}
+
+
 class TestModuleVarTorchOps:
     def test_library_block_uses_declared_module_variable(self):
         code = (

--- a/tests/test_binding_detector.py
+++ b/tests/test_binding_detector.py
@@ -356,3 +356,79 @@ class TestEnclosingFunctionKeywords:
         graph = BindingDetector().detect_bindings("/d.cpp", code)
         disp = next(b for b in graph.bindings if b.binding_type == "at_dispatch")
         assert disp.cpp_name == "gelu_impl"
+
+
+class TestSearchDirBounds:
+    """Directory scans honor manifest cpp_search_dirs."""
+
+    _CODE = 'TORCH_LIBRARY(aten, m) { m.def("relu(Tensor self) -> Tensor"); }\n'
+
+    def _repo(self, tmp_path_factory):
+        # mktemp instead of tmp_path: tmp_path embeds the test name, whose
+        # "test_" segment trips the scanner's exclusion patterns.
+        repo = tmp_path_factory.mktemp("scandir")
+        (repo / "csrc").mkdir()
+        (repo / "vendored").mkdir()
+        (repo / "csrc" / "inside.cpp").write_text(self._CODE)
+        (repo / "vendored" / "outside.cpp").write_text(self._CODE)
+        return repo
+
+    def test_scan_limited_to_search_dirs(self, tmp_path_factory):
+        repo = self._repo(tmp_path_factory)
+        detector = BindingDetector(search_dirs=("csrc",))
+        graph = detector.detect_bindings_in_directory(str(repo))
+        files = {b.file_path for b in graph.bindings}
+        assert files
+        assert all("vendored" not in f for f in files)
+
+    def test_unbounded_detector_scans_whole_tree(self, tmp_path_factory):
+        repo = self._repo(tmp_path_factory)
+        graph = BindingDetector().detect_bindings_in_directory(str(repo))
+        files = {b.file_path for b in graph.bindings}
+        assert any("vendored" in f for f in files)
+        assert any("csrc" in f for f in files)
+
+    def test_missing_search_dirs_scan_nothing(self, tmp_path_factory):
+        repo = self._repo(tmp_path_factory)
+        detector = BindingDetector(search_dirs=("nonexistent",))
+        graph = detector.detect_bindings_in_directory(str(repo))
+        assert graph.bindings == []
+
+
+class TestManifestExcludeAndPrefilter:
+    """Manifest exclude_patterns and registration_macros drive directory scans."""
+
+    _CODE = 'TORCH_LIBRARY(aten, m) { m.def("relu(Tensor self) -> Tensor"); }\n'
+
+    def _repo(self, tmp_path_factory):
+        repo = tmp_path_factory.mktemp("scandir")
+        (repo / "csrc" / "generated").mkdir(parents=True)
+        (repo / "csrc" / "tests").mkdir()
+        (repo / "csrc" / "generated" / "gen.cpp").write_text(self._CODE)
+        (repo / "csrc" / "tests" / "helper.cpp").write_text(self._CODE)
+        return repo
+
+    def test_manifest_excludes_replace_defaults(self, tmp_path_factory):
+        repo = self._repo(tmp_path_factory)
+        detector = BindingDetector(search_dirs=("csrc",), exclude_patterns=("/tests/",))
+        graph = detector.detect_bindings_in_directory(str(repo))
+        files = {b.file_path for b in graph.bindings}
+        assert any("generated" in f for f in files)
+        assert not any("/tests/" in f for f in files)
+
+    def test_default_excludes_apply_when_manifest_unset(self, tmp_path_factory):
+        repo = self._repo(tmp_path_factory)
+        detector = BindingDetector(search_dirs=("csrc",))
+        graph = detector.detect_bindings_in_directory(str(repo))
+        assert graph.bindings == []
+
+    def test_registration_macros_prefilter(self, tmp_path_factory):
+        repo = tmp_path_factory.mktemp("scandir")
+        (repo / "csrc").mkdir()
+        (repo / "csrc" / "ops.cpp").write_text(self._CODE)
+        detector = BindingDetector(
+            search_dirs=("csrc",), registration_macros=("CUSTOM_REGISTER",)
+        )
+        assert detector.detect_bindings_in_directory(str(repo)).bindings == []
+        fallback = BindingDetector(search_dirs=("csrc",))
+        assert fallback.detect_bindings_in_directory(str(repo)).bindings

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -88,13 +88,13 @@ class TestIndexUpdateExitCode:
         import torchtalk.cli as cli_mod
         from torchtalk import indexer
 
-        monkeypatch.setattr(
-            "torchtalk.config.resolve_pytorch_source", lambda: "/tmp/fake"
-        )
+        monkeypatch.setattr("torchtalk.config.resolve_source", lambda **kw: "/tmp/fake")
         monkeypatch.setattr(
             indexer, "update_index", lambda *a, **kw: self._fake_stats(True)
         )
-        args = Namespace(since="baseline", pytorch_source=None, on_uncovered="fail")
+        args = Namespace(
+            since="baseline", source=None, on_uncovered="fail", harness=None
+        )
         assert cli_mod.cmd_index_update(args) == 1
 
     def test_returns_zero_when_no_uncovered_fail(self, monkeypatch):
@@ -103,13 +103,13 @@ class TestIndexUpdateExitCode:
         import torchtalk.cli as cli_mod
         from torchtalk import indexer
 
-        monkeypatch.setattr(
-            "torchtalk.config.resolve_pytorch_source", lambda: "/tmp/fake"
-        )
+        monkeypatch.setattr("torchtalk.config.resolve_source", lambda **kw: "/tmp/fake")
         monkeypatch.setattr(
             indexer, "update_index", lambda *a, **kw: self._fake_stats(False)
         )
-        args = Namespace(since="baseline", pytorch_source=None, on_uncovered="warn")
+        args = Namespace(
+            since="baseline", source=None, on_uncovered="warn", harness=None
+        )
         assert cli_mod.cmd_index_update(args) == 0
 
 
@@ -188,7 +188,7 @@ class TestFormatFlag:
             {
                 "harness": None,
                 "format": "markdown",
-                "pytorch_source": None,
+                "source": None,
                 "index": None,
                 "transport": "stdio",
             },

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,136 @@
+"""Tests for per-harness source configuration."""
+
+from __future__ import annotations
+
+import pytest
+
+from torchtalk import config
+from torchtalk.config import (
+    default_harness,
+    resolve_source,
+    set_source,
+    source_env_var,
+    validate_source_path,
+)
+from torchtalk.harness import get_harness
+
+
+@pytest.fixture
+def isolated_config(tmp_path, monkeypatch):
+    """Point config reads/writes at tmp_path and clear source env vars."""
+    monkeypatch.setattr(config, "CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(config, "CONFIG_FILE", tmp_path / "config.toml")
+    for var in ("PYTORCH_SOURCE", "PYTORCH_PATH"):
+        monkeypatch.delenv(var, raising=False)
+    return tmp_path
+
+
+class TestSourceEnvVar:
+    def test_simple_name(self):
+        assert source_env_var("vllm") == "TORCHTALK_SOURCE_VLLM"
+
+    def test_non_alphanumeric_normalized(self):
+        assert source_env_var("my-fork.v2") == "TORCHTALK_SOURCE_MY_FORK_V2"
+
+
+class TestResolveSource:
+    def test_cli_flag_wins(self, isolated_config):
+        assert resolve_source("vllm", cli_flag="/cli/path") == "/cli/path"
+
+    def test_env_var_beats_config(self, isolated_config, tmp_path, monkeypatch):
+        env_dir = tmp_path / "env_src"
+        env_dir.mkdir()
+        set_source("vllm", "/config/path")
+        monkeypatch.setenv("TORCHTALK_SOURCE_VLLM", str(env_dir))
+        assert resolve_source("vllm") == str(env_dir)
+
+    def test_env_var_with_missing_path_skipped(self, isolated_config, monkeypatch):
+        monkeypatch.setenv("TORCHTALK_SOURCE_VLLM", "/does/not/exist")
+        assert resolve_source("vllm") is None
+
+    def test_legacy_pytorch_env_honored(self, isolated_config, tmp_path, monkeypatch):
+        env_dir = tmp_path / "pt_src"
+        env_dir.mkdir()
+        monkeypatch.setenv("PYTORCH_SOURCE", str(env_dir))
+        assert resolve_source("pytorch") == str(env_dir)
+        assert resolve_source("vllm") is None
+
+    def test_sources_table(self, isolated_config, tmp_path):
+        src = tmp_path / "vllm_src"
+        src.mkdir()
+        set_source("vllm", str(src))
+        assert resolve_source("vllm") == str(src)
+        assert resolve_source("pytorch") is None
+
+    def test_legacy_config_key_pytorch_only(self, isolated_config, tmp_path):
+        src = tmp_path / "pt_src"
+        src.mkdir()
+        (tmp_path / "config.toml").write_text(f'[source]\npytorch_source = "{src}"\n')
+        assert resolve_source("pytorch") == str(src)
+        assert resolve_source("vllm") is None
+
+
+class TestSetSource:
+    def test_pytorch_mirrors_legacy_key(self, isolated_config):
+        set_source("pytorch", "/pt")
+        cfg = config.load_config()
+        assert cfg["sources"]["pytorch"] == "/pt"
+        assert cfg["source"]["pytorch_source"] == "/pt"
+
+    def test_other_harness_no_legacy_key(self, isolated_config):
+        set_source("vllm", "/vllm")
+        cfg = config.load_config()
+        assert cfg["sources"]["vllm"] == "/vllm"
+        assert "source" not in cfg
+
+    def test_make_default(self, isolated_config):
+        set_source("vllm", "/vllm", make_default=True)
+        assert default_harness() == "vllm"
+
+    def test_default_unset(self, isolated_config):
+        set_source("vllm", "/vllm")
+        assert default_harness() is None
+
+    def test_multiple_harnesses_coexist(self, isolated_config):
+        set_source("pytorch", "/pt")
+        set_source("vllm", "/vllm")
+        cfg = config.load_config()
+        assert cfg["sources"] == {"pytorch": "/pt", "vllm": "/vllm"}
+
+
+class TestValidateSourcePath:
+    def test_missing_path(self, tmp_path):
+        manifest = get_harness("pytorch").manifest
+        valid, msg = validate_source_path(tmp_path / "ghost", manifest)
+        assert not valid
+        assert "does not exist" in msg
+
+    def test_pytorch_requires_yaml(self, tmp_path):
+        (tmp_path / "torch").mkdir()
+        manifest = get_harness("pytorch").manifest
+        valid, msg = validate_source_path(tmp_path, manifest)
+        assert not valid
+        assert "native_functions.yaml" in msg
+
+    def test_pytorch_valid_checkout(self, tmp_path):
+        (tmp_path / "torch").mkdir()
+        nf = tmp_path / "aten/src/ATen/native/native_functions.yaml"
+        nf.parent.mkdir(parents=True)
+        nf.write_text("")
+        manifest = get_harness("pytorch").manifest
+        valid, msg = validate_source_path(tmp_path, manifest)
+        assert valid
+        assert "pytorch" in msg
+
+    def test_vllm_accepts_csrc_layout(self, tmp_path):
+        (tmp_path / "csrc").mkdir()
+        manifest = get_harness("vllm").manifest
+        valid, _ = validate_source_path(tmp_path, manifest)
+        assert valid
+
+    def test_vllm_rejects_unrelated_dir(self, tmp_path):
+        (tmp_path / "random").mkdir()
+        manifest = get_harness("vllm").manifest
+        valid, msg = validate_source_path(tmp_path, manifest)
+        assert not valid
+        assert "vllm" in msg

--- a/tests/test_cpp_call_graph.py
+++ b/tests/test_cpp_call_graph.py
@@ -81,7 +81,7 @@ class TestSynthesizeMissingCuEntries:
     def relax_exclude(self, monkeypatch):
         # pytest's tmp_path contains "test_" which matches EXCLUDE_PATTERNS.
         # Replace should_exclude with one that only flags real exclude patterns.
-        def stub(path: str) -> bool:
+        def stub(path: str, patterns=None) -> bool:
             return "/test/" in path or "/third_party/" in path
 
         monkeypatch.setattr(cpp_call_graph, "should_exclude", stub)
@@ -645,7 +645,9 @@ class TestSupportedExtensions:
         (src / "compile_commands.json").write_text(json.dumps(db))
 
         monkeypatch.setattr(cpp_call_graph, "_discover_cuda_env", lambda: None)
-        monkeypatch.setattr(cpp_call_graph, "should_exclude", lambda _p: False)
+        monkeypatch.setattr(
+            cpp_call_graph, "should_exclude", lambda _p, _pat=None: False
+        )
         monkeypatch.setattr(cpp_call_graph, "should_include_dir", lambda _p, _d: True)
         monkeypatch.setattr(cpp_call_graph, "Pool", _FakePool)
 

--- a/tests/test_dispatch_stub_map.py
+++ b/tests/test_dispatch_stub_map.py
@@ -88,3 +88,114 @@ class TestExtractKernelImplToOp:
     def test_handles_missing_native_dir(self, tmp_path):
         # No aten/src/ATen/native/ exists at all.
         assert extract_kernel_impl_to_op(tmp_path, {"foo": {}}) == {}
+
+
+class TestCallSiteStubBridge:
+    """Stubs whose name never strips to a YAML op resolve via their call site."""
+
+    def test_flash_attention_shape(self, tmp_path):
+        _write(
+            tmp_path,
+            "cpu/FlashAttentionKernel.cpp",
+            "ALSO_REGISTER_AVX512_DISPATCH(flash_attention_kernel, "
+            "&flash_attention_kernel_impl)\n",
+        )
+        _write(
+            tmp_path,
+            "transformers/attention.cpp",
+            "std::tuple<Tensor, Tensor> "
+            "_scaled_dot_product_flash_attention_for_cpu(const Tensor& q) {\n"
+            "  if (q.defined()) {\n"
+            "    flash_attention_kernel(kCPU, output, logsumexp);\n"
+            "  }\n"
+            "  return out;\n"
+            "}\n",
+        )
+        out = extract_kernel_impl_to_op(
+            tmp_path, {"_scaled_dot_product_flash_attention_for_cpu": {}}
+        )
+        assert out == {
+            "flash_attention_kernel_impl": (
+                "_scaled_dot_product_flash_attention_for_cpu"
+            )
+        }
+
+    def test_unresolvable_call_site_stays_unmapped(self, tmp_path):
+        _write(tmp_path, "cpu/K.cpp", "REGISTER_DISPATCH(weird_stub, &weird_impl)\n")
+        _write(
+            tmp_path,
+            "Helpers.cpp",
+            "void some_helper(Tensor& t) {\n  weird_stub(kCPU, t);\n}\n",
+        )
+        out = extract_kernel_impl_to_op(tmp_path, {"unrelated_op": {}})
+        assert out == {}
+
+    def test_direct_resolution_not_overridden(self, tmp_path):
+        _write(
+            tmp_path,
+            "cpu/Act.cpp",
+            "REGISTER_DISPATCH(gelu_stub, &gelu_kernel_cpu)\n",
+        )
+        out = extract_kernel_impl_to_op(tmp_path, {"gelu": {}})
+        assert out == {"gelu_kernel_cpu": "gelu"}
+
+
+class TestCallSiteImplResolution:
+    def test_enclosing_dispatch_impl_resolves_via_yaml_table(self, tmp_path):
+        _write(
+            tmp_path,
+            "cpu/FlashAttentionKernel.cpp",
+            "REGISTER_DISPATCH(flash_attention_kernel, &flash_attention_kernel_impl)\n",
+        )
+        _write(
+            tmp_path,
+            "transformers/attention.cpp",
+            "std::tuple<Tensor, Tensor> _sdpa_flash_cpu(const Tensor& q) {\n"
+            "  flash_attention_kernel(kCPU, out);\n"
+            "  return out;\n"
+            "}\n",
+        )
+        nf = {
+            "_sdpa_flash_for_cpu": {"dispatch": {"CPU": "_sdpa_flash_cpu"}},
+        }
+        out = extract_kernel_impl_to_op(tmp_path, nf)
+        assert out["flash_attention_kernel_impl"] == "_sdpa_flash_for_cpu"
+
+
+class TestKernelTuHelperMapping:
+    def test_helpers_in_kernel_tu_map_to_its_ops(self, tmp_path):
+        _write(
+            tmp_path,
+            "cpu/FlashAttentionKernel.cpp",
+            "void cpu_flash_attention(Tensor& out) {\n}\n"
+            "void cpu_flash_attention_backward(Tensor& g) {\n}\n"
+            "void flash_attention_kernel_impl(Tensor& out) {\n"
+            "  cpu_flash_attention(out);\n"
+            "}\n"
+            "void flash_attention_backward_kernel_impl(Tensor& g) {\n"
+            "  cpu_flash_attention_backward(g);\n"
+            "}\n"
+            "REGISTER_DISPATCH(fwd_stub, &flash_attention_kernel_impl)\n"
+            "REGISTER_DISPATCH(bwd_stub, &flash_attention_backward_kernel_impl)\n",
+        )
+        _write(
+            tmp_path,
+            "transformers/attention.cpp",
+            "Tensor sdpa_for_cpu(const Tensor& q) {\n  fwd_stub(kCPU, q);\n"
+            "  return q;\n}\n"
+            "Tensor sdpa_for_cpu_backward(const Tensor& g) {\n"
+            "  bwd_stub(kCPU, g);\n  return g;\n}\n",
+        )
+        nf = {"sdpa_for_cpu": {}, "sdpa_for_cpu_backward": {}}
+        out = extract_kernel_impl_to_op(tmp_path, nf)
+        assert out["cpu_flash_attention"] == "sdpa_for_cpu"
+        assert out["cpu_flash_attention_backward"] == "sdpa_for_cpu_backward"
+
+    def test_many_op_files_do_not_blanket_map_helpers(self, tmp_path):
+        body = "".join(
+            f"REGISTER_DISPATCH(op{i}_stub, &op{i}_kernel)\n" for i in range(6)
+        )
+        _write(tmp_path, "cpu/Big.cpp", body + "void shared_helper(int x) {\n}\n")
+        nf = {f"op{i}": {} for i in range(6)}
+        out = extract_kernel_impl_to_op(tmp_path, nf)
+        assert "shared_helper" not in out

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -1,0 +1,228 @@
+"""Tests for config-driven registration extractors and qualname resolver."""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from tests.conftest import get_pytorch_path
+from torchtalk.analysis.extractors import (
+    extract_registrations,
+    resolve_qualname_literals,
+)
+from torchtalk.harness import PYTORCH_MANIFEST, CallRegistration, ConventionManifest
+
+
+def _manifest(**kwargs) -> ConventionManifest:
+    return ConventionManifest(package="fake", cpp_search_dirs=(), **kwargs)
+
+
+def _write(tmp_path, rel: str, body: str):
+    p = tmp_path / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(body)
+    return p
+
+
+class TestDecoratorRegistries:
+    def test_string_key_decorator_on_class(self, tmp_path):
+        _write(
+            tmp_path,
+            "pkg/ops.py",
+            "@CustomOp.register('silu_and_mul')\nclass SiluAndMul:\n    pass\n",
+        )
+        m = _manifest(decorator_registries={"CustomOp.register": "custom_ops"})
+        out = extract_registrations(tmp_path, m)
+        assert out["records"] == [
+            {
+                "registry": "custom_ops",
+                "key": "silu_and_mul",
+                "target": "pkg.ops.SiluAndMul",
+                "kind": "resolved",
+                "via": "decorator",
+                "file": "pkg/ops.py",
+                "line": 2,
+            }
+        ]
+
+    def test_dotted_and_list_keys(self, tmp_path):
+        _write(
+            tmp_path,
+            "pkg/decomp.py",
+            "@register_decomposition(aten.gelu)\ndef gelu(x):\n    pass\n\n"
+            "@register_decomposition([aten.abs, aten.neg])\ndef absneg(x):\n    pass\n",
+        )
+        m = _manifest(decorator_registries={"register_decomposition": "decomp"})
+        keys = {r["key"] for r in extract_registrations(tmp_path, m)["records"]}
+        assert keys == {"aten.gelu", "aten.abs", "aten.neg"}
+
+    def test_bare_decorator_uses_decorated_name_as_key(self, tmp_path):
+        _write(tmp_path, "pkg/b.py", "@register_backend\ndef inductor(g):\n    pass\n")
+        m = _manifest(decorator_registries={"register_backend": "backends"})
+        (rec,) = extract_registrations(tmp_path, m)["records"]
+        assert rec["key"] == "inductor"
+        assert rec["target"] == "pkg.b.inductor"
+
+
+class TestStringRegistries:
+    def test_vllm_tuple_shape_is_candidate(self, tmp_path):
+        _write(
+            tmp_path,
+            "pkg/registry.py",
+            "_VLLM_MODELS = {\n"
+            "    'LlamaForCausalLM': ('llama', 'LlamaForCausalLM'),\n"
+            "}\n",
+        )
+        m = _manifest(string_registries=("_VLLM_MODELS",))
+        (rec,) = extract_registrations(tmp_path, m)["records"]
+        assert rec["registry"] == "_VLLM_MODELS"
+        assert rec["key"] == "LlamaForCausalLM"
+        assert rec["target"] == "llama.LlamaForCausalLM"
+        assert rec["kind"] == "candidate"
+        assert rec["evidence"] == "llama.LlamaForCausalLM"
+
+    def test_hf_import_structure_list_shape(self, tmp_path):
+        _write(
+            tmp_path,
+            "pkg/init_stub.py",
+            "_import_structure = {'models.llama': ['LlamaModel', 'LlamaConfig']}\n",
+        )
+        m = _manifest(string_registries=("_import_structure",))
+        targets = {r["target"] for r in extract_registrations(tmp_path, m)["records"]}
+        assert targets == {"models.llama.LlamaModel", "models.llama.LlamaConfig"}
+
+    def test_qualname_string_value(self, tmp_path):
+        _write(tmp_path, "pkg/r.py", "_REG = {'k': 'pkg.mod.Cls'}\n")
+        m = _manifest(string_registries=("_REG",))
+        (rec,) = extract_registrations(tmp_path, m)["records"]
+        assert rec["target"] == "pkg.mod.Cls"
+
+    def test_undeclared_registry_ignored(self, tmp_path):
+        _write(tmp_path, "pkg/r.py", "_OTHER = {'k': 'pkg.mod.Cls'}\n")
+        m = _manifest(string_registries=("_REG",))
+        assert extract_registrations(tmp_path, m)["records"] == []
+
+
+class TestRegistrationCalls:
+    def test_kwarg_roles(self, tmp_path):
+        _write(
+            tmp_path,
+            "pkg/c.py",
+            "direct_register_custom_op(op_name='rms_norm', op_func=rms_norm_impl)\n",
+        )
+        m = _manifest(
+            registration_calls=(
+                CallRegistration(
+                    "direct_register_custom_op", "op_name", "op_func", "custom_ops"
+                ),
+            )
+        )
+        (rec,) = extract_registrations(tmp_path, m)["records"]
+        assert rec == {
+            "registry": "custom_ops",
+            "key": "rms_norm",
+            "target": "rms_norm_impl",
+            "kind": "resolved",
+            "via": "call",
+            "file": "pkg/c.py",
+            "line": 1,
+        }
+
+    def test_positional_roles_and_default_registry(self, tmp_path):
+        _write(tmp_path, "pkg/c.py", "register_op('fused_moe', fused_moe_kernel)\n")
+        m = _manifest(registration_calls=(CallRegistration("register_op", 0, 1),))
+        (rec,) = extract_registrations(tmp_path, m)["records"]
+        assert rec["registry"] == "register_op"
+        assert rec["key"] == "fused_moe"
+        assert rec["target"] == "fused_moe_kernel"
+
+
+class TestStringDispatchers:
+    def test_dispatch_emits_candidate_edge_with_evidence(self, tmp_path):
+        _write(
+            tmp_path,
+            "pkg/engine.py",
+            "class Engine:\n"
+            "    def start(self):\n"
+            "        self.collective_rpc('init_worker')\n",
+        )
+        m = _manifest(string_dispatchers={"collective_rpc": 0})
+        (edge,) = extract_registrations(tmp_path, m)["candidate_edges"]
+        assert edge == {
+            "kind": "candidate",
+            "via": "string_dispatch",
+            "source": "pkg.engine.Engine.start",
+            "target": "init_worker",
+            "evidence": "init_worker",
+            "file": "pkg/engine.py",
+            "line": 3,
+        }
+
+    def test_non_literal_arg_emits_nothing(self, tmp_path):
+        _write(tmp_path, "pkg/e.py", "rpc.collective_rpc(method_name)\n")
+        m = _manifest(string_dispatchers={"collective_rpc": 0})
+        assert extract_registrations(tmp_path, m)["candidate_edges"] == []
+
+
+class TestQualnameResolver:
+    def test_literal_matching_indexed_qualname_becomes_candidate(self, tmp_path):
+        _write(tmp_path, "pkg/models.py", "class Foo:\n    pass\n")
+        _write(
+            tmp_path,
+            "pkg/engine.py",
+            "def launch():\n    load('pkg.models.Foo')\n",
+        )
+        m = _manifest(string_dispatchers={"never_called": 0})
+        edges = extract_registrations(tmp_path, m)["candidate_edges"]
+        assert edges == [
+            {
+                "kind": "candidate",
+                "via": "qualname_literal",
+                "source": "pkg.engine.launch",
+                "target": "pkg.models.Foo",
+                "evidence": "pkg.models.Foo",
+                "file": "pkg/engine.py",
+                "line": 2,
+            }
+        ]
+
+    def test_unmatched_literals_emit_nothing(self):
+        lits = [{"value": "no.such.Thing", "scope": "m.f", "file": "f", "line": 1}]
+        assert resolve_qualname_literals(lits, {"pkg.models.Foo"}) == []
+
+    def test_plain_words_never_collected(self, tmp_path):
+        _write(tmp_path, "pkg/w.py", "def f():\n    x = 'launch'\n")
+        m = _manifest(string_dispatchers={"never_called": 0})
+        assert extract_registrations(tmp_path, m)["candidate_edges"] == []
+
+
+class TestManifestGating:
+    def test_unconfigured_manifest_skips_walk(self, tmp_path):
+        _write(tmp_path, "pkg/r.py", "_REG = {'k': 'pkg.mod.Cls'}\n")
+        out = extract_registrations(tmp_path, _manifest())
+        assert out == {"records": [], "candidate_edges": []}
+
+    def test_exclude_patterns_respected(self, tmp_path):
+        _write(
+            tmp_path,
+            "pkg/test_x.py",
+            "@CustomOp.register('k')\nclass C:\n    pass\n",
+        )
+        m = _manifest(
+            decorator_registries={"CustomOp.register": "custom_ops"},
+            exclude_patterns=("test_",),
+        )
+        assert extract_registrations(tmp_path, m)["records"] == []
+
+
+@pytest.mark.skipif(get_pytorch_path() is None, reason="PyTorch source not available")
+class TestAgainstPyTorch:
+    def test_register_decomposition_records_found(self):
+        src = get_pytorch_path()
+        m = dataclasses.replace(PYTORCH_MANIFEST, python_search_dirs=("torch/_decomp",))
+        out = extract_registrations(src, m)
+        decomp = [r for r in out["records"] if r["registry"] == "decompositions"]
+        assert len(decomp) > 100
+        assert all(r["kind"] == "resolved" and r["via"] == "decorator" for r in decomp)
+        assert any(r["key"].startswith("aten.") for r in decomp)

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -151,5 +151,8 @@ class TestRelativePath:
     def test_strips_pytorch_fallback_without_base(self):
         assert relative_path("pytorch/aten/x.cpp") == "aten/x.cpp"
 
+    def test_strips_checkout_name_for_other_repos(self):
+        assert relative_path("vllm/csrc/ops.cpp", "/scratch/vllm") == "csrc/ops.cpp"
+
     def test_unrelated_path_unchanged(self):
         assert relative_path("other/x.cpp", "/src/pytorch") == "other/x.cpp"

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -55,3 +55,25 @@ class TestRealRepoManifests:
     def test_vllm_and_torchvision_registered(self):
         assert harness_mod.get_harness("vllm").manifest.package == "vllm"
         assert harness_mod.get_harness("torchvision").manifest.package == "torchvision"
+
+
+class TestCachePathsHarnessQualified:
+    def test_explicit_package_qualifies_filenames(self):
+        from torchtalk.config import cache_paths
+
+        paths = cache_paths("/src", package="vllm")
+        assert all("vllm" in p.name for p in paths.values())
+
+    def test_default_follows_active_harness(self):
+        from torchtalk.config import cache_paths
+
+        try:
+            harness_mod.set_active_harness("vllm")
+            vllm_paths = cache_paths("/src")
+        finally:
+            harness_mod.set_active_harness("pytorch")
+        pytorch_paths = cache_paths("/src")
+        assert all("vllm" in p.name for p in vllm_paths.values())
+        assert all("pytorch" in p.name for p in pytorch_paths.values())
+        for key, path in pytorch_paths.items():
+            assert path != vllm_paths[key]

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -1,0 +1,57 @@
+"""Tests for the harness convention manifest."""
+
+import dataclasses
+
+import pytest
+
+from torchtalk import harness as harness_mod
+from torchtalk.harness import (
+    PYTORCH_HARNESS,
+    PYTORCH_MANIFEST,
+    ConventionManifest,
+    Harness,
+)
+
+
+class TestPyTorchManifest:
+    def test_harness_satisfies_protocol(self):
+        assert isinstance(PYTORCH_HARNESS, Harness)
+        assert PYTORCH_HARNESS.manifest is PYTORCH_MANIFEST
+
+
+class TestHarnessRegistry:
+    @pytest.fixture(autouse=True)
+    def restore_active(self):
+        try:
+            yield
+        finally:
+            harness_mod.set_active_harness("pytorch")
+            harness_mod._REGISTRY.pop("fakerepo", None)
+
+    def test_pytorch_registered_as_default(self):
+        assert harness_mod.get_harness() is PYTORCH_HARNESS
+        assert harness_mod.active_manifest() is PYTORCH_MANIFEST
+
+    def test_register_and_activate(self):
+        m = ConventionManifest(package="fakerepo", cpp_search_dirs=("csrc",))
+
+        @dataclasses.dataclass(frozen=True)
+        class FakeHarness:
+            manifest: ConventionManifest = m
+
+        harness_mod.register_harness("fakerepo", FakeHarness())
+        harness_mod.set_active_harness("fakerepo")
+        assert harness_mod.active_manifest().package == "fakerepo"
+        assert harness_mod.get_harness("pytorch") is PYTORCH_HARNESS
+
+    def test_unknown_harness_raises(self):
+        with pytest.raises(KeyError, match="Unknown harness"):
+            harness_mod.get_harness("nonexistent")
+        with pytest.raises(KeyError, match="Unknown harness"):
+            harness_mod.set_active_harness("nonexistent")
+
+
+class TestRealRepoManifests:
+    def test_vllm_and_torchvision_registered(self):
+        assert harness_mod.get_harness("vllm").manifest.package == "vllm"
+        assert harness_mod.get_harness("torchvision").manifest.package == "torchvision"

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -387,12 +387,74 @@ class TestUpdateIndex:
         with pytest.raises(ValueError, match="no git_commit"):
             update_index(str(tmp_path / "src"), since="baseline")
 
+    def test_raises_on_cross_package_snapshot(self, tmp_path, monkeypatch):
+        cache = tmp_path / "cache"
+        snap_dir = cache / "snapshots" / "baseline"
+        snap_dir.mkdir(parents=True)
+        (snap_dir / "manifest.json").write_text(
+            json.dumps(
+                {
+                    "name": "baseline",
+                    "created": "2026-01-01T00:00:00+00:00",
+                    "pytorch_source": str(tmp_path / "src"),
+                    "source_fingerprint": "deadbeef",
+                    "git_commit": "abc1234",
+                    "bindings_size": 0,
+                    "bindings_sha256": "x",
+                    "content_fingerprint": None,
+                    "package": "vllm",
+                    "schema_version": 3,
+                }
+            )
+        )
+        (snap_dir / "bindings.json").write_text(json.dumps({"bindings": []}))
+        monkeypatch.setattr(snapshots, "SNAPSHOTS_DIR", cache / "snapshots")
+
+        with pytest.raises(ValueError, match="'vllm' harness"):
+            update_index(str(tmp_path / "src"), since="baseline")
+
+    def test_raises_on_old_format_baseline(self, tmp_path, monkeypatch):
+        cache = tmp_path / "cache"
+        snap_dir = cache / "snapshots" / "baseline"
+        snap_dir.mkdir(parents=True)
+        (snap_dir / "manifest.json").write_text(
+            json.dumps(
+                {
+                    "name": "baseline",
+                    "created": "2026-01-01T00:00:00+00:00",
+                    "pytorch_source": str(tmp_path / "src"),
+                    "source_fingerprint": "deadbeef",
+                    "git_commit": "abc1234",
+                    "bindings_size": 0,
+                    "bindings_sha256": "x",
+                    "content_fingerprint": None,
+                    "schema_version": 2,
+                }
+            )
+        )
+        (snap_dir / "bindings.json").write_text(
+            json.dumps({"bindings": [], "metadata": {"format_version": 2}})
+        )
+        monkeypatch.setattr(snapshots, "SNAPSHOTS_DIR", cache / "snapshots")
+
+        with pytest.raises(ValueError, match="cache format v2"):
+            update_index(str(tmp_path / "src"), since="baseline")
+
     def test_drops_and_reindexes_changed_files(self, tmp_path, monkeypatch):
-        """Stale bindings for changed files are dropped; re-detected entries added."""
+        """Stale bindings for changed files are dropped; re-detected entries added.
+
+        Changed files outside the manifest's C++ search dirs lose their stale
+        bindings but are not re-detected (harness boundary).
+        """
         import subprocess
 
         src = tmp_path / "src"
-        src.mkdir()
+        changed_rel = "aten/src/ATen/native/changed.cpp"
+        outside_rel = "tools/outside.cpp"
+        excluded_rel = "aten/src/ATen/native/test_helper.cpp"
+        unpatterned_rel = "aten/src/ATen/native/plain.cpp"
+        (src / changed_rel).parent.mkdir(parents=True)
+        (src / outside_rel).parent.mkdir(parents=True)
         cache = tmp_path / "cache"
         snap_dir = cache / "snapshots" / "baseline"
         snap_dir.mkdir(parents=True)
@@ -403,7 +465,7 @@ class TestUpdateIndex:
                     "python_name": "stale",
                     "cpp_name": "at::stale",
                     "dispatch_key": "CPU",
-                    "file_path": str(src / "changed.cpp"),
+                    "file_path": str(src / changed_rel),
                     "line_number": 1,
                 },
                 {
@@ -413,11 +475,19 @@ class TestUpdateIndex:
                     "file_path": str(src / "untouched.cpp"),
                     "line_number": 2,
                 },
+                {
+                    "python_name": "outside",
+                    "cpp_name": "at::outside",
+                    "dispatch_key": "CPU",
+                    "file_path": str(src / outside_rel),
+                    "line_number": 3,
+                },
             ],
             "cuda_kernels": [],
             "native_functions": {},
             "derivatives": {},
             "native_implementations": {},
+            "metadata": {"format_version": indexer._BINDINGS_CACHE_FORMAT_VERSION},
         }
         (snap_dir / "bindings.json").write_text(json.dumps(baseline_bindings))
         (snap_dir / "manifest.json").write_text(
@@ -435,7 +505,10 @@ class TestUpdateIndex:
                 }
             )
         )
-        (src / "changed.cpp").write_text("// new content")
+        (src / changed_rel).write_text("TORCH_LIBRARY(aten, m) {}")
+        (src / outside_rel).write_text("TORCH_LIBRARY(aten, m) {}")
+        (src / excluded_rel).write_text("TORCH_LIBRARY(aten, m) {}")
+        (src / unpatterned_rel).write_text("// no binding patterns here")
 
         monkeypatch.setattr(snapshots, "SNAPSHOTS_DIR", cache / "snapshots")
         monkeypatch.setattr(indexer, "CACHE_DIR", cache)
@@ -449,7 +522,10 @@ class TestUpdateIndex:
 
         def fake_diff(cmd, **kwargs):
             class R:
-                stdout = "M\tchanged.cpp\n"
+                stdout = (
+                    f"M\t{changed_rel}\nM\t{outside_rel}\n"
+                    f"M\t{excluded_rel}\nM\t{unpatterned_rel}\n"
+                )
 
             return R()
 
@@ -463,7 +539,7 @@ class TestUpdateIndex:
                             "python_name": "reindexed",
                             "cpp_name": "at::reindexed",
                             "dispatch_key": "CPU",
-                            "file_path": str(src / "changed.cpp"),
+                            "file_path": str(src / changed_rel),
                             "line_number": 5,
                         }
 
@@ -483,8 +559,10 @@ class TestUpdateIndex:
 
         stats = update_index(str(src), since="baseline")
 
-        assert stats["cpp_files_changed"] == 1
-        assert stats["bindings_total"] == 2  # stable + reindexed, stale dropped
+        assert stats["cpp_files_changed"] == 4
+        # stable + reindexed; stale dropped; the out-of-bounds, excluded, and
+        # pattern-free changed files are not re-detected
+        assert stats["bindings_total"] == 2
 
         written = json.loads(Path(cache / "bindings.json").read_text())
         names = {b["python_name"] for b in written["bindings"]}
@@ -768,7 +846,16 @@ class TestUpdateIndexMetadata:
         cache = tmp_path / "cache"
         snap_dir = cache / "snapshots" / "baseline"
         snap_dir.mkdir(parents=True)
-        (snap_dir / "bindings.json").write_text(json.dumps({"bindings": []}))
+        (snap_dir / "bindings.json").write_text(
+            json.dumps(
+                {
+                    "bindings": [],
+                    "metadata": {
+                        "format_version": indexer._BINDINGS_CACHE_FORMAT_VERSION
+                    },
+                }
+            )
+        )
         (snap_dir / "manifest.json").write_text(
             json.dumps(
                 {

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -3,6 +3,7 @@
 import ast
 import json
 import subprocess
+from dataclasses import asdict
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -15,6 +16,7 @@ from torchtalk.analysis.python_analyzer import (
     PyFunction,
     PyModule,
 )
+from torchtalk.harness import ConventionManifest
 from torchtalk.indexer import (
     _FREE_FUNC_RE,
     _METHOD_FUNC_RE,
@@ -32,6 +34,7 @@ from torchtalk.indexer import (
     _save_py_cpp_edges_cache,
     update_index,
 )
+from torchtalk.symbols import PackageIdentity
 
 
 class TestServerState:
@@ -438,6 +441,11 @@ class TestUpdateIndex:
         monkeypatch.setattr(indexer, "CACHE_DIR", cache)
         monkeypatch.setattr(indexer, "_cache_path", lambda _s: cache / "bindings.json")
         monkeypatch.setattr(indexer, "_source_fingerprint", lambda _s: "newfp")
+        monkeypatch.setattr(
+            indexer,
+            "detect_package_identity",
+            lambda _s, _n: PackageIdentity("pytorch", "abc123def456"),
+        )
 
         def fake_diff(cmd, **kwargs):
             class R:
@@ -463,6 +471,9 @@ class TestUpdateIndex:
                 self.cuda_kernels = []
 
         class FakeDetector:
+            def __init__(self, **_kwargs):
+                pass
+
             def detect_bindings(self, _path, _content):
                 return FakeBindingGraph()
 
@@ -628,6 +639,74 @@ class TestCollectTestAttrHits:
         assert index["copy_"][0]["receiver_type"] is None
 
 
+class TestCacheValidPackageIdentity:
+    @pytest.fixture(autouse=True)
+    def stub_identity(self, monkeypatch):
+        monkeypatch.setattr(indexer, "_source_fingerprint", lambda _s: "fp")
+        monkeypatch.setattr(
+            indexer,
+            "detect_package_identity",
+            lambda _s, _n: PackageIdentity("pytorch", "abc123def456"),
+        )
+
+    def _write(self, tmp_path, meta):
+        cache = tmp_path / "bindings.json"
+        cache.write_text(json.dumps({"bindings": [], "metadata": meta}))
+        return cache
+
+    def _meta(self, **overrides):
+        meta = {
+            "format_version": indexer._BINDINGS_CACHE_FORMAT_VERSION,
+            "source_fingerprint": "fp",
+            "package": {"name": "pytorch", "revision": "abc123def456"},
+        }
+        meta.update(overrides)
+        return meta
+
+    def test_accepts_matching_metadata(self, tmp_path):
+        assert indexer._cache_valid(self._write(tmp_path, self._meta()), "/src") is True
+
+    def test_rejects_revision_mismatch(self, tmp_path):
+        meta = self._meta(package={"name": "pytorch", "revision": "fff000fff000"})
+        assert indexer._cache_valid(self._write(tmp_path, meta), "/src") is False
+
+    def test_rejects_missing_package(self, tmp_path):
+        meta = self._meta()
+        del meta["package"]
+        assert indexer._cache_valid(self._write(tmp_path, meta), "/src") is False
+
+    def test_rejects_old_format_version(self, tmp_path):
+        meta = self._meta(format_version=indexer._BINDINGS_CACHE_FORMAT_VERSION - 1)
+        assert indexer._cache_valid(self._write(tmp_path, meta), "/src") is False
+
+
+class TestBuildIndexPackageMetadata:
+    def test_metadata_carries_package_identity(self, tmp_path, monkeypatch):
+        src = tmp_path / "src"
+        src.mkdir()
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+        monkeypatch.setattr(indexer, "CACHE_DIR", cache_dir)
+        monkeypatch.setattr(
+            indexer, "_cache_path", lambda _s: cache_dir / "bindings.json"
+        )
+        monkeypatch.setattr(
+            indexer,
+            "detect_package_identity",
+            lambda _s, _n: PackageIdentity("pytorch", "abc123def456"),
+        )
+
+        data = indexer._build_index(str(src))
+
+        assert data["metadata"]["package"] == {
+            "name": "pytorch",
+            "revision": "abc123def456",
+        }
+        assert (
+            data["metadata"]["format_version"] == indexer._BINDINGS_CACHE_FORMAT_VERSION
+        )
+
+
 class TestCacheInvalidationByGitState:
     """_cache_valid must reject caches after commits/pulls and dirty edits."""
 
@@ -651,7 +730,13 @@ class TestCacheInvalidationByGitState:
             json.dumps(
                 {
                     "bindings": [],
-                    "metadata": indexer._cache_metadata(str(src)),
+                    "metadata": {
+                        "format_version": indexer._BINDINGS_CACHE_FORMAT_VERSION,
+                        "source_fingerprint": indexer._source_fingerprint(str(src)),
+                        "package": asdict(
+                            indexer.detect_package_identity(str(src), "pytorch")
+                        ),
+                    },
                 }
             )
         )
@@ -705,6 +790,11 @@ class TestUpdateIndexMetadata:
         monkeypatch.setattr(indexer, "CACHE_DIR", cache)
         monkeypatch.setattr(indexer, "_cache_path", lambda _s: cache_file)
         monkeypatch.setattr(indexer, "_source_fingerprint", lambda _s: "fp")
+        monkeypatch.setattr(
+            indexer,
+            "detect_package_identity",
+            lambda _s, _n: PackageIdentity("pytorch", "abc123def456"),
+        )
 
         def fake_diff(cmd, **kwargs):
             class R:
@@ -724,6 +814,62 @@ class TestUpdateIndexMetadata:
         cache_file, src = self._run_noop_update(tmp_path, monkeypatch)
         written = json.loads(cache_file.read_text())["metadata"]
         assert set(indexer._cache_metadata(str(src))) <= set(written)
+
+
+class TestBuildIndexRegistrations:
+    def test_registration_records_land_in_index_and_cache(self, tmp_path, monkeypatch):
+        src = tmp_path / "src"
+        (src / "pkg").mkdir(parents=True)
+        (src / "pkg" / "ops.py").write_text(
+            "@CustomOp.register('silu')\nclass Silu:\n    pass\n"
+        )
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+        monkeypatch.setattr(indexer, "CACHE_DIR", cache_dir)
+        monkeypatch.setattr(
+            indexer, "_cache_path", lambda _s: cache_dir / "bindings.json"
+        )
+        monkeypatch.setattr(
+            indexer,
+            "detect_package_identity",
+            lambda _s, _n: PackageIdentity("fake", "abc123def456"),
+        )
+        m = ConventionManifest(
+            package="fake",
+            cpp_search_dirs=(),
+            python_search_dirs=("pkg",),
+            decorator_registries={"CustomOp.register": "custom_ops"},
+        )
+
+        data = indexer._build_index(str(src), manifest=m)
+
+        (rec,) = data["registrations"]["records"]
+        assert rec["key"] == "silu"
+        assert rec["target"] == "pkg.ops.Silu"
+        assert rec["kind"] == "resolved"
+        cached = json.loads((cache_dir / "bindings.json").read_text())
+        assert cached["registrations"]["records"] == [rec]
+
+
+class TestManifestYamlSources:
+    def test_custom_yaml_path_honored(self, tmp_path):
+        (tmp_path / "defs").mkdir()
+        (tmp_path / "defs" / "ops.yaml").write_text("- func: foo() -> Tensor\n")
+        m = ConventionManifest(
+            package="fake", cpp_search_dirs=(), native_functions_yaml="defs/ops.yaml"
+        )
+        functions, derivatives = indexer._parse_native_functions(str(tmp_path), m)
+        assert "foo" in functions
+        assert derivatives == {}
+
+    def test_undeclared_yaml_sources_are_skipped(self, tmp_path):
+        nf = tmp_path / "aten/src/ATen/native/native_functions.yaml"
+        nf.parent.mkdir(parents=True)
+        nf.write_text("- func: bar() -> Tensor\n")
+        m = ConventionManifest(package="fake", cpp_search_dirs=())
+        functions, derivatives = indexer._parse_native_functions(str(tmp_path), m)
+        assert functions == {}
+        assert derivatives == {}
 
 
 class TestFuzzyFindDeterminism:

--- a/tests/test_python_analyzer.py
+++ b/tests/test_python_analyzer.py
@@ -290,3 +290,22 @@ class TestImportAwareResolution:
             alias_map={"torch.linalg.cross": "aten::linalg_cross"},
         )
         assert module.functions[0].cpp_bindings == []
+
+
+class TestPackageRoots:
+    def test_manifest_roots_drive_module_names(self, tmp_path):
+        pkg = tmp_path / "vllm" / "engine"
+        pkg.mkdir(parents=True)
+        f = pkg / "llm.py"
+        f.write_text("class LLM:\n    pass\n")
+        analyzer = PythonAnalyzer(package_roots=("vllm",))
+        module = analyzer.analyze_file(str(f))
+        assert module.name == "vllm.engine.llm"
+
+    def test_default_roots_unchanged(self, tmp_path):
+        pkg = tmp_path / "torch" / "nn"
+        pkg.mkdir(parents=True)
+        f = pkg / "linear.py"
+        f.write_text("class Linear:\n    pass\n")
+        module = PythonAnalyzer().analyze_file(str(f))
+        assert module.name == "torch.nn.linear"

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -64,7 +64,7 @@ def fake_cache(tmp_path, monkeypatch):
     monkeypatch.setattr(snapshots, "CACHE_DIR", cache)
     monkeypatch.setattr(snapshots, "SNAPSHOTS_DIR", cache / "snapshots")
     monkeypatch.setattr(snapshots, "cache_paths", fake_cache_paths)
-    monkeypatch.setattr(snapshots, "resolve_pytorch_source", lambda: source)
+    monkeypatch.setattr(snapshots, "resolve_source", lambda: source)
 
     return {
         "cache": cache,
@@ -134,7 +134,7 @@ class TestSaveSnapshot:
             save_snapshot("v1")
 
     def test_no_source_raises(self, fake_cache, monkeypatch):
-        monkeypatch.setattr(snapshots, "resolve_pytorch_source", lambda: None)
+        monkeypatch.setattr(snapshots, "resolve_source", lambda: None)
         with pytest.raises(SnapshotError, match="No PyTorch source"):
             save_snapshot("v1")
 
@@ -166,38 +166,18 @@ class TestLoadSnapshot:
 
     def test_fingerprint_mismatch_refused(self, fake_cache, monkeypatch):
         save_snapshot("v1")
-        # Swap the live cache to a different fingerprint
-        other_fp = "cafebabe9999"
-        other_bindings = fake_cache["cache"] / f"bindings_{other_fp}.json"
-        other_bindings.write_text("{}")
-        monkeypatch.setattr(
-            snapshots,
-            "cache_paths",
-            lambda _: {
-                "bindings": other_bindings,
-                "callgraph": other_bindings.parent
-                / "call_graph"
-                / f"pytorch_callgraph_parallel_{other_fp}.json",
-            },
-        )
+        # Point the live config at a different source checkout
+        other_src = fake_cache["cache"].parent / "other_pytorch"
+        other_src.mkdir()
+        monkeypatch.setattr(snapshots, "resolve_source", lambda: str(other_src))
         with pytest.raises(SnapshotError, match="Fingerprint mismatch"):
             load_snapshot("v1")
 
     def test_fingerprint_mismatch_force_loads(self, fake_cache, monkeypatch):
         save_snapshot("v1")
-        other_fp = "cafebabe9999"
-        other_bindings = fake_cache["cache"] / f"bindings_{other_fp}.json"
-        other_bindings.write_text("{}")
-        monkeypatch.setattr(
-            snapshots,
-            "cache_paths",
-            lambda _: {
-                "bindings": other_bindings,
-                "callgraph": other_bindings.parent
-                / "call_graph"
-                / f"pytorch_callgraph_parallel_{other_fp}.json",
-            },
-        )
+        other_src = fake_cache["cache"].parent / "other_pytorch"
+        other_src.mkdir()
+        monkeypatch.setattr(snapshots, "resolve_source", lambda: str(other_src))
         manifest = load_snapshot("v1", force=True)
         assert manifest.name == "v1"
 
@@ -482,19 +462,9 @@ class TestContentFingerprint:
         save_snapshot("v1")
 
         monkeypatch.setattr(snapshots, "_content_fingerprint", lambda _: "different")
-        other_fp = "cafebabe9999"
-        other_bindings = fake_cache["cache"] / f"bindings_{other_fp}.json"
-        other_bindings.write_text("{}")
-        monkeypatch.setattr(
-            snapshots,
-            "cache_paths",
-            lambda _: {
-                "bindings": other_bindings,
-                "callgraph": other_bindings.parent
-                / "call_graph"
-                / f"pytorch_callgraph_parallel_{other_fp}.json",
-            },
-        )
+        other_src = fake_cache["cache"].parent / "other_pytorch"
+        other_src.mkdir()
+        monkeypatch.setattr(snapshots, "resolve_source", lambda: str(other_src))
         with pytest.raises(SnapshotError, match="Fingerprint mismatch"):
             load_snapshot("v1")
 
@@ -559,7 +529,7 @@ class TestFindNearestSnapshot:
         assert find_nearest_snapshot() is None
 
     def test_none_when_no_source(self, fake_cache, monkeypatch):
-        monkeypatch.setattr(snapshots, "resolve_pytorch_source", lambda: None)
+        monkeypatch.setattr(snapshots, "resolve_source", lambda: None)
         assert find_nearest_snapshot() is None
 
     def test_prefers_exact_over_ancestor(self, fake_cache, monkeypatch):
@@ -595,3 +565,29 @@ class TestFindNearestSnapshot:
         picked = find_nearest_snapshot()
         assert picked is not None
         assert picked.name == "by_content"
+
+
+class TestHarnessPackageGuard:
+    def test_save_records_active_package(self, fake_cache):
+        manifest = save_snapshot("v1")
+        assert manifest.package == "pytorch"
+
+    def test_load_refuses_cross_package(self, fake_cache, monkeypatch):
+        from torchtalk.harness import get_harness
+
+        save_snapshot("v1")
+        monkeypatch.setattr(
+            snapshots, "active_manifest", lambda: get_harness("vllm").manifest
+        )
+        with pytest.raises(SnapshotError, match="'pytorch' harness"):
+            load_snapshot("v1")
+
+    def test_pre_v3_manifest_loads_without_package(self, fake_cache):
+        save_snapshot("v1")
+        mf = fake_cache["cache"] / "snapshots" / "v1" / "manifest.json"
+        data = json.loads(mf.read_text())
+        data["schema_version"] = 2
+        data.pop("package")
+        mf.write_text(json.dumps(data))
+        manifest = load_snapshot("v1")
+        assert manifest.package == ""

--- a/tests/test_symbols.py
+++ b/tests/test_symbols.py
@@ -1,0 +1,130 @@
+"""Tests for package-qualified symbol identity."""
+
+import subprocess
+
+import pytest
+
+from torchtalk.symbols import (
+    UNKNOWN_REVISION,
+    PackageIdentity,
+    content_fingerprint,
+    detect_package_identity,
+    make_symbol_id,
+    parse_symbol_id,
+)
+
+
+class TestSymbolIds:
+    def test_make_and_parse_round_trip(self):
+        pkg = PackageIdentity("pytorch", "a1b2c3d4e5f6")
+        sid = make_symbol_id(pkg, "at::native::add")
+        assert sid == "pytorch@a1b2c3d4e5f6/at::native::add"
+        assert parse_symbol_id(sid) == (pkg, "at::native::add")
+
+    def test_symbol_with_overload_dot(self):
+        pkg = PackageIdentity("pytorch", "2.9.0a0")
+        assert parse_symbol_id(make_symbol_id(pkg, "add.Tensor")) == (
+            pkg,
+            "add.Tensor",
+        )
+
+    def test_symbol_containing_slash(self):
+        pkg = PackageIdentity("vllm", "abc123")
+        sid = make_symbol_id(pkg, "csrc/ops.h::rotary_embedding")
+        assert parse_symbol_id(sid) == (pkg, "csrc/ops.h::rotary_embedding")
+
+    @pytest.mark.parametrize(
+        "bad",
+        ["", "pytorch/add", "pytorch@abc", "@abc/add", "pytorch@/add", "pytorch@abc/"],
+    )
+    def test_parse_rejects_malformed(self, bad):
+        with pytest.raises(ValueError, match="Malformed symbol ID"):
+            parse_symbol_id(bad)
+
+
+class TestDetectPackageIdentity:
+    def test_git_repo_head_sha(self, tmp_path):
+        subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+        (tmp_path / "f.txt").write_text("x")
+        subprocess.run(["git", "add", "f.txt"], cwd=tmp_path, check=True)
+        subprocess.run(
+            ["git", "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "x"],
+            cwd=tmp_path,
+            check=True,
+        )
+        head = subprocess.run(
+            ["git", "rev-parse", "--short=12", "HEAD"],
+            cwd=tmp_path,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+        assert detect_package_identity(tmp_path, name="myrepo") == PackageIdentity(
+            "myrepo", head
+        )
+
+    def test_detached_head_file_fallback(self, tmp_path):
+        sha = "1234567890abcdef1234567890abcdef12345678"
+        git_dir = tmp_path / ".git"
+        (git_dir / "objects").mkdir(parents=True)
+        (git_dir / "refs").mkdir()
+        (git_dir / "HEAD").write_text(sha + "\n")
+        assert detect_package_identity(tmp_path, "pytorch").revision == sha[:12]
+
+    def test_version_txt_fallback(self, tmp_path):
+        (tmp_path / "version.txt").write_text("2.9.0a0\n")
+        assert detect_package_identity(tmp_path, "pytorch") == PackageIdentity(
+            "pytorch", "2.9.0a0"
+        )
+
+    def test_version_py_fallback(self, tmp_path):
+        pkg_dir = tmp_path / "mylib"
+        pkg_dir.mkdir()
+        (pkg_dir / "version.py").write_text('__version__ = "1.2.3"\n')
+        assert detect_package_identity(tmp_path, name="mylib") == PackageIdentity(
+            "mylib", "1.2.3"
+        )
+
+    def test_unknown_when_nothing_found(self, tmp_path):
+        assert detect_package_identity(tmp_path, "pytorch").revision == (
+            UNKNOWN_REVISION
+        )
+
+
+class TestContentFingerprint:
+    def _commit(self, cwd, msg):
+        subprocess.run(
+            ["git", "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qam", msg],
+            cwd=cwd,
+            check=True,
+        )
+
+    def _repo(self, tmp_path):
+        subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+        (tmp_path / "kernel.cu").write_text("v1")
+        subprocess.run(["git", "add", "kernel.cu"], cwd=tmp_path, check=True)
+        self._commit(tmp_path, "init")
+        return tmp_path
+
+    def test_stable_across_noop_calls(self, tmp_path):
+        repo = self._repo(tmp_path)
+        assert content_fingerprint(repo) == content_fingerprint(repo)
+
+    def test_changes_on_new_commit(self, tmp_path):
+        repo = self._repo(tmp_path)
+        before = content_fingerprint(repo)
+        (repo / "kernel.cu").write_text("v2")
+        self._commit(repo, "edit")
+        assert content_fingerprint(repo) != before
+
+    def test_changes_on_dirty_edit_and_re_edit(self, tmp_path):
+        repo = self._repo(tmp_path)
+        clean = content_fingerprint(repo)
+        (repo / "kernel.cu").write_text("v2")
+        dirty = content_fingerprint(repo)
+        assert dirty != clean
+        (repo / "kernel.cu").write_text("v3")
+        assert content_fingerprint(repo) not in (clean, dirty)
+
+    def test_non_git_returns_none(self, tmp_path):
+        assert content_fingerprint(tmp_path) is None


### PR DESCRIPTION
## Add repository harnesses: TorchTalk beyond PyTorch

TorchTalk's indexing pipeline was hardwired to one repo's anatomy PyTorch's directory layout, YAML files, test conventions, and cache identity were baked into constants scattered across the codebase. This PR introduces the **repository harness**: a declarative `ConventionManifest` that captures everything TorchTalk needs to know to index a package C++/Python/test search directories, exclusion patterns, registration macros and macro aliases, YAML data sources, decorator/string registries, and package identity. The engine consumes only the manifest; the repo-specific knowledge lives in ~30 lines of data per package.

Three harnesses ship built-in **pytorch**, **vllm**, **torchvision** and `register_harness()` accepts new ones without engine changes. Graphs built from different manifests merge via package-qualified symbol IDs (`pytorch@<rev>/at::native::add`).

### The harness boundary is enforced everywhere

Every scan  binding detection, implementation search, C++ call graph (full and incremental), Python registration extraction, test-infrastructure analysis is bounded by the active manifest's search dirs, exclusion patterns, and prefilters. Incremental updates (`index update --since`) apply the identical boundary, so they can never produce an index a full rebuild wouldn't.

### Identity is harness-qualified

Caches are keyed by package and source (`bindings_vllm_<hash>.json`), so indexing two repos or one checkout under two harnesses never collides. Snapshots record which harness built them (schema v3, migrated transparently) and refuse cross-harness load/update with an actionable error. Baselines from older cache formats are rejected instead of silently merging mixed-schema rows.

### Multi-repo config, end to end

```
torchtalk init --harness vllm --source /repos/vllm --set-default
torchtalk index build            # default harness from config
torchtalk status                 # per-harness sources, validity, caches
```

Sources live per-harness in `[sources]`; resolution is flag → `TORCHTALK_SOURCE_<HARNESS>` env (derived from the name, nothing hardcoded) → config. Validation is manifest-driven, so `init` accepts a vLLM checkout and still holds PyTorch to its old strictness. `--pytorch-source`, `PYTORCH_SOURCE`, and the legacy config key remain as compatible aliases; the Claude Code plugin pins `--harness pytorch`.
