### PR TITLE
Strengthening integration assertions and add server coverage

### DIFF
--- a/.github/workflows/harness-smoke.yml
+++ b/.github/workflows/harness-smoke.yml
@@ -11,6 +11,7 @@ on:
       - "src/torchtalk/analysis/binding_detector.py"
       - "src/torchtalk/indexer.py"
       - "scripts/harness_smoke.py"
+      - "tests/integration/**"
       - ".github/workflows/harness-smoke.yml"
 
 jobs:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -25,10 +25,12 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Install torchtalk
+        run: pip install -e ".[dev]"
+
       - name: Read manifest
         id: manifest
         run: |
-          pip install pyyaml -q
           python3 << 'SCRIPT'
           import yaml, os
 
@@ -57,9 +59,6 @@ jobs:
 
       - name: Set source env var
         run: echo "${{ steps.manifest.outputs.env_var }}=${{ github.workspace }}/_target" >> $GITHUB_ENV
-
-      - name: Install torchtalk
-        run: pip install -e ".[dev]"
 
       - name: Run integration tests
         run: python -m pytest tests/test_binding_detector_pytorch.py -v

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,31 +1,65 @@
-repo: https://github.com/pytorch/pytorch.git
-ref: v2.13.0
-env_var: PYTORCH_SOURCE
-sparse_paths:
-  - torch/csrc
-  - aten/src/ATen/native
+name: Integration Tests
 
-anchors:
-  - file: torch/csrc/Module.cpp
-    check: pybind_name
-    value: _WeakTensorRef
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [main]
+    paths:
+      - "src/torchtalk/analysis/**"
+      - "tests/test_binding_detector_pytorch.py"
+      - "tests/integration/**"
+      - ".github/workflows/integration-tests.yml"
 
-  - file: aten/src/ATen/native/RNN.cpp
-    check: torch_library_cpp_name
-    value: quantized_lstm
+jobs:
+  integration:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target: [pytorch]
+    steps:
+      - name: Checkout torchtalk
+        uses: actions/checkout@v4
 
-  - dir: aten/src/ATen/native/cuda
-    check: has_cuda_kernel
-    glob: "*.cu"
-    content_filter: __global__
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
 
-  - dir: aten/src/ATen/native
-    check: has_at_dispatch
-    glob: "*.cpp"
-    content_filter: AT_DISPATCH
+      - name: Read manifest
+        id: manifest
+        run: |
+          pip install pyyaml -q
+          python3 << 'SCRIPT'
+          import yaml, os
 
-  - dir: torch/csrc/autograd
-    check: has_binding_types
-    value:
-      - pybind_method
-      - torch_library_impl
+          with open("tests/integration/${{ matrix.target }}.yml") as f:
+              m = yaml.safe_load(f)
+
+          out = os.environ["GITHUB_OUTPUT"]
+          with open(out, "a") as f:
+              f.write(f"repo={m['repo']}\n")
+              f.write(f"ref={m['ref']}\n")
+              f.write(f"env_var={m['env_var']}\n")
+              f.write("sparse_paths<<EOF\n")
+              for p in m["sparse_paths"]:
+                  f.write(f"{p}\n")
+              f.write("EOF\n")
+          SCRIPT
+
+      - name: Sparse checkout target
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ steps.manifest.outputs.repo }}
+          ref: ${{ steps.manifest.outputs.ref }}
+          sparse-checkout: ${{ steps.manifest.outputs.sparse_paths }}
+          filter: blob:none
+          path: _target
+
+      - name: Set source env var
+        run: echo "${{ steps.manifest.outputs.env_var }}=${{ github.workspace }}/_target" >> $GITHUB_ENV
+
+      - name: Install torchtalk
+        run: pip install -e ".[dev]"
+
+      - name: Run integration tests
+        run: python -m pytest tests/test_binding_detector_pytorch.py -v

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,31 @@
+repo: https://github.com/pytorch/pytorch.git
+ref: v2.13.0
+env_var: PYTORCH_SOURCE
+sparse_paths:
+  - torch/csrc
+  - aten/src/ATen/native
+
+anchors:
+  - file: torch/csrc/Module.cpp
+    check: pybind_name
+    value: _WeakTensorRef
+
+  - file: aten/src/ATen/native/RNN.cpp
+    check: torch_library_cpp_name
+    value: quantized_lstm
+
+  - dir: aten/src/ATen/native/cuda
+    check: has_cuda_kernel
+    glob: "*.cu"
+    content_filter: __global__
+
+  - dir: aten/src/ATen/native
+    check: has_at_dispatch
+    glob: "*.cpp"
+    content_filter: AT_DISPATCH
+
+  - dir: torch/csrc/autograd
+    check: has_binding_types
+    value:
+      - pybind_method
+      - torch_library_impl

--- a/scripts/harness_smoke.py
+++ b/scripts/harness_smoke.py
@@ -1,5 +1,8 @@
 """Harness smoke test: validates that a harness config indexes a real repo.
 
+Reads repo/ref/sparse_paths from tests/integration/<target>.yml (single
+source of truth). Thresholds live here since they're smoke-specific.
+
 Usage:
     python scripts/harness_smoke.py --harness pytorch --source /path/to/pytorch
     python scripts/harness_smoke.py --harness pytorch --clone
@@ -14,16 +17,13 @@ import sys
 import tempfile
 from pathlib import Path
 
-CLONE_CONFIGS = {
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MANIFESTS_DIR = REPO_ROOT / "tests" / "integration"
+
+SMOKE_THRESHOLDS = {
     "pytorch": {
-        "repo": "https://github.com/pytorch/pytorch.git",
-        "ref": "v2.13.0",
-        "sparse_paths": [
-            "aten/src/ATen/native",
-            "torch/csrc",
-            "torch/nn",
-            "tools/autograd",
-        ],
         # Thresholds: min across v2.10-v2.13 sparse-clone results minus
         # 10% buffer. Absorbs restructures like the v2.13 native_functions
         # drop (2869->2762) without false alarms.
@@ -38,10 +38,24 @@ CLONE_CONFIGS = {
 _STABLE_TAG = re.compile(r"^v(\d+)\.(\d+)\.(\d+)$")
 
 
-def latest_stable_tag(repo: str) -> str:
+def _load_manifest(target: str) -> dict:
+    """Load the integration manifest for a target."""
+    path = MANIFESTS_DIR / f"{target}.yml"
+    if not path.exists():
+        sys.exit(f"Manifest not found: {path}")
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+def _clone_url(repo: str) -> str:
+    """Convert owner/repo to a clone URL."""
+    return f"https://github.com/{repo}.git"
+
+
+def latest_stable_tag(repo_url: str) -> str:
     """Resolve the latest stable release tag (excludes -rc, -beta, etc.)."""
     result = subprocess.run(
-        ["git", "ls-remote", "--tags", repo],
+        ["git", "ls-remote", "--tags", repo_url],
         capture_output=True,
         text=True,
         check=True,
@@ -54,12 +68,12 @@ def latest_stable_tag(repo: str) -> str:
         if m:
             tags.append((int(m.group(1)), int(m.group(2)), int(m.group(3)), ref))
     if not tags:
-        raise RuntimeError(f"No stable tags found in {repo}")
+        raise RuntimeError(f"No stable tags found in {repo_url}")
     tags.sort()
     return tags[-1][3]
 
 
-def sparse_clone(repo: str, ref: str, paths: list[str], dest: Path) -> None:
+def sparse_clone(repo_url: str, ref: str, paths: list[str], dest: Path) -> None:
     subprocess.run(
         [
             "git",
@@ -69,7 +83,7 @@ def sparse_clone(repo: str, ref: str, paths: list[str], dest: Path) -> None:
             ref,
             "--sparse",
             "--no-checkout",
-            repo,
+            repo_url,
             str(dest),
         ],
         check=True,
@@ -82,39 +96,33 @@ def sparse_clone(repo: str, ref: str, paths: list[str], dest: Path) -> None:
     subprocess.run(["git", "checkout"], cwd=dest, check=True)
 
 
-def _run_index(harness_name: str, source: Path) -> dict:
-    from torchtalk.harness import set_active_harness
-    from torchtalk.indexer import build_index
-
-    set_active_harness(harness_name)
-    return build_index(str(source), wait_for_cpp=False)
-
-
 def main():
+    targets = sorted(SMOKE_THRESHOLDS.keys())
     parser = argparse.ArgumentParser(description="Harness smoke test")
-    parser.add_argument("--harness", required=True, choices=list(CLONE_CONFIGS.keys()))
+    parser.add_argument("--harness", required=True, choices=targets)
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument("--source", type=Path)
     group.add_argument("--clone", action="store_true")
     args = parser.parse_args()
 
-    config = CLONE_CONFIGS[args.harness]
+    manifest = _load_manifest(args.harness)
+    repo_url = _clone_url(manifest["repo"])
+    ref = manifest.get("ref") or latest_stable_tag(repo_url)
+    sparse_paths = manifest["sparse_paths"]
 
     if args.clone:
-        ref = config.get("ref") or latest_stable_tag(config["repo"])
         print(f"Using ref: {ref}")
         with tempfile.TemporaryDirectory() as tmp:
             source = Path(tmp) / "repo"
-            sparse_clone(config["repo"], ref, config["sparse_paths"], source)
+            sparse_clone(repo_url, ref, sparse_paths, source)
             stats = _run_index(args.harness, source)
     else:
         stats = _run_index(args.harness, args.source)
 
+    thresholds = SMOKE_THRESHOLDS[args.harness]
     failures = []
-    for key, threshold in config.items():
-        if not key.startswith("min_"):
-            continue
-        field = key[4:]
+    for key, threshold in thresholds.items():
+        field = key.removeprefix("min_")
         actual = stats.get(field, 0)
         print(f"  {field}: {actual} (threshold: >= {threshold})")
         if actual < threshold:
@@ -127,6 +135,14 @@ def main():
         sys.exit(1)
 
     print("\nPassed.")
+
+
+def _run_index(harness_name: str, source: Path) -> dict:
+    from torchtalk.harness import set_active_harness
+    from torchtalk.indexer import build_index
+
+    set_active_harness(harness_name)
+    return build_index(str(source), wait_for_cpp=False)
 
 
 if __name__ == "__main__":

--- a/tests/integration/pytorch.yml
+++ b/tests/integration/pytorch.yml
@@ -1,0 +1,31 @@
+repo: https://github.com/pytorch/pytorch.git
+ref: v2.13.0
+env_var: PYTORCH_SOURCE
+sparse_paths:
+  - torch/csrc
+  - aten/src/ATen/native
+
+anchors:
+  - file: torch/csrc/Module.cpp
+    check: pybind_name
+    value: _WeakTensorRef
+
+  - file: aten/src/ATen/native/RNN.cpp
+    check: torch_library_cpp_name
+    value: quantized_lstm
+
+  - dir: aten/src/ATen/native/cuda
+    check: has_cuda_kernel
+    glob: "*.cu"
+    content_filter: __global__
+
+  - dir: aten/src/ATen/native
+    check: has_at_dispatch
+    glob: "*.cpp"
+    content_filter: AT_DISPATCH
+
+  - dir: torch/csrc/autograd
+    check: has_binding_types
+    value:
+      - pybind_method
+      - torch_library_impl

--- a/tests/integration/pytorch.yml
+++ b/tests/integration/pytorch.yml
@@ -4,6 +4,8 @@ env_var: PYTORCH_SOURCE
 sparse_paths:
   - torch/csrc
   - aten/src/ATen/native
+  - torch/nn
+  - tools/autograd
 
 anchors:
   - file: torch/csrc/Module.cpp

--- a/tests/integration/pytorch.yml
+++ b/tests/integration/pytorch.yml
@@ -1,4 +1,4 @@
-repo: https://github.com/pytorch/pytorch.git
+repo: pytorch/pytorch
 ref: v2.13.0
 env_var: PYTORCH_SOURCE
 sparse_paths:

--- a/tests/test_binding_detector_pytorch.py
+++ b/tests/test_binding_detector_pytorch.py
@@ -1,23 +1,82 @@
 """
-Test BindingDetector against the actual PyTorch repository.
+Test BindingDetector against real repositories using manifest-driven anchors.
 
-Requires PYTORCH_SOURCE or PYTORCH_PATH environment variable to be set.
+Each YAML file in tests/integration/ defines a target repo with anchors
+(file -> expected symbol). Tests are parametrized over these anchors so
+adding a new target is a YAML file, not new test code.
+
+Requires the manifest's env_var (e.g. PYTORCH_SOURCE) to point at a checkout.
+Skips when the env var is unset.
 
 Usage:
     PYTORCH_SOURCE=/path/to/pytorch pytest tests/test_binding_detector_pytorch.py -v
 """
 
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
 import pytest
+import yaml
 
 from torchtalk.analysis.binding_detector import BindingDetector, BindingType
 
-from .conftest import get_pytorch_path
+MANIFESTS_DIR = Path(__file__).parent / "integration"
 
-PYTORCH_PATH = get_pytorch_path()
+
+def _load_manifests() -> list[dict]:
+    """Load all YAML manifests from tests/integration/."""
+    manifests = []
+    if MANIFESTS_DIR.exists():
+        for path in sorted(MANIFESTS_DIR.glob("*.yml")):
+            with open(path) as f:
+                manifest = yaml.safe_load(f)
+                manifest["_name"] = path.stem
+                manifests.append(manifest)
+    return manifests
+
+
+def _source_path(manifest: dict) -> Path | None:
+    """Resolve source path from the manifest's env_var."""
+    env_var = manifest.get("env_var", "")
+    for var in (env_var, f"{env_var}_PATH"):
+        if val := os.environ.get(var):
+            p = Path(val)
+            if p.exists():
+                return p
+    return None
+
+
+MANIFESTS = _load_manifests()
+
+
+def _anchor_ids() -> list[str]:
+    """Build readable test IDs from manifests."""
+    ids = []
+    for m in MANIFESTS:
+        for anchor in m.get("anchors", []):
+            check = anchor["check"]
+            target = anchor.get("file") or anchor.get("dir", "")
+            ids.append(f"{m['_name']}/{check}/{Path(target).name}")
+    return ids
+
+
+def _anchor_params() -> list[tuple[dict, dict, Path | None]]:
+    """Build (manifest, anchor, source_path) tuples for parametrize."""
+    params = []
+    for m in MANIFESTS:
+        source = _source_path(m)
+        for anchor in m.get("anchors", []):
+            params.append((m, anchor, source))
+    return params
+
+
+PARAMS = _anchor_params()
 
 pytestmark = pytest.mark.skipif(
-    PYTORCH_PATH is None,
-    reason="PYTORCH_SOURCE or PYTORCH_PATH environment variable not set",
+    not PARAMS or all(p[2] is None for p in PARAMS),
+    reason="No integration manifests with available source checkouts",
 )
 
 
@@ -27,69 +86,102 @@ def detector():
     return BindingDetector()
 
 
-class TestPybind11Detection:
-    def test_detects_bindings_in_module_cpp(self, detector):
-        test_file = PYTORCH_PATH / "torch/csrc/Module.cpp"
-        if not test_file.exists():
-            pytest.skip(f"Test file not found: {test_file}")
+class TestIntegrationAnchors:
+    """Parametrized integration tests driven by YAML manifests."""
 
-        content = test_file.read_text(errors="replace")
-        graph = detector.detect_bindings(str(test_file), content)
+    @pytest.mark.parametrize(
+        "manifest,anchor,source",
+        PARAMS,
+        ids=_anchor_ids() if PARAMS else [],
+    )
+    def test_anchor(self, detector, manifest, anchor, source):
+        """Verify a single anchor from the integration manifest."""
+        if source is None:
+            pytest.skip(f"{manifest.get('env_var')} not set")
+
+        check = anchor["check"]
+
+        if check == "pybind_name":
+            self._check_pybind_name(detector, source, anchor)
+        elif check == "torch_library_cpp_name":
+            self._check_torch_library_cpp_name(detector, source, anchor)
+        elif check == "has_cuda_kernel":
+            self._check_has_cuda_kernel(detector, source, anchor)
+        elif check == "has_at_dispatch":
+            self._check_has_at_dispatch(detector, source, anchor)
+        elif check == "has_binding_types":
+            self._check_has_binding_types(detector, source, anchor)
+        else:
+            pytest.fail(f"Unknown check type: {check}")
+
+    def _check_pybind_name(self, detector, source, anchor):
+        """Assert a specific python_name exists in bindings for a file."""
+        path = source / anchor["file"]
+        if not path.exists():
+            pytest.skip(f"File not found: {path}")
+
+        content = path.read_text(errors="replace")
+        graph = detector.detect_bindings(str(path), content)
 
         names = {b.python_name for b in graph.bindings if b.python_name}
-        assert "_WeakTensorRef" in names, (
-            f"Expected _WeakTensorRef in Module.cpp, got: {sorted(names)[:10]}"
+        expected = anchor["value"]
+        assert expected in names, (
+            f"Expected {expected} in {anchor['file']}, got: {sorted(names)[:10]}"
         )
 
+    def _check_torch_library_cpp_name(self, detector, source, anchor):
+        """Assert a specific cpp_name exists in TORCH_LIBRARY bindings."""
+        path = source / anchor["file"]
+        if not path.exists():
+            pytest.skip(f"File not found: {path}")
 
-class TestTorchLibraryDetection:
-    def test_detects_torch_library_in_rnn(self, detector):
-        test_file = PYTORCH_PATH / "aten/src/ATen/native/RNN.cpp"
-        if not test_file.exists():
-            pytest.skip(f"Test file not found: {test_file}")
-
-        content = test_file.read_text(errors="replace")
-        graph = detector.detect_bindings(str(test_file), content)
+        content = path.read_text(errors="replace")
+        graph = detector.detect_bindings(str(path), content)
 
         cpp_names = {b.cpp_name for b in graph.bindings if b.cpp_name}
-        assert "quantized_lstm" in cpp_names, (
-            f"Expected quantized_lstm in RNN.cpp bindings, got: {sorted(cpp_names)}"
+        expected = anchor["value"]
+        assert expected in cpp_names, (
+            f"Expected {expected} in {anchor['file']}, got: {sorted(cpp_names)}"
         )
 
+    def _check_has_cuda_kernel(self, detector, source, anchor):
+        """Assert at least one CUDA kernel with a non-empty name is found."""
+        scan_dir = source / anchor["dir"]
+        if not scan_dir.exists():
+            pytest.skip(f"Directory not found: {scan_dir}")
 
-class TestCudaKernelDetection:
-    def test_detects_cuda_kernels(self, detector):
-        cuda_dir = PYTORCH_PATH / "aten/src/ATen/native/cuda"
-        if not cuda_dir.exists():
-            pytest.skip(f"CUDA directory not found: {cuda_dir}")
+        glob_pattern = anchor.get("glob", "*.cu")
+        content_filter = anchor.get("content_filter", "__global__")
 
         found_kernel = None
-        for cu_file in list(cuda_dir.glob("*.cu"))[:20]:
+        for cu_file in sorted(scan_dir.glob(glob_pattern))[:20]:
             content = cu_file.read_text(errors="replace")
-            if "__global__" not in content:
+            if content_filter not in content:
                 continue
-
             graph = detector.detect_bindings(str(cu_file), content)
             if graph.cuda_kernels:
                 found_kernel = graph.cuda_kernels[0]
                 break
 
-        assert found_kernel is not None, "Should find a CUDA kernel in native/cuda/"
-        assert found_kernel.name, "Kernel must have a non-empty name"
+        assert found_kernel is not None, f"No CUDA kernel found in {anchor['dir']}"
+        assert found_kernel.name, (
+            f"Kernel in {anchor['dir']} must have a non-empty name"
+        )
 
+    def _check_has_at_dispatch(self, detector, source, anchor):
+        """Assert at least one AT_DISPATCH binding with a cpp_name is found."""
+        scan_dir = source / anchor["dir"]
+        if not scan_dir.exists():
+            pytest.skip(f"Directory not found: {scan_dir}")
 
-class TestAtDispatchDetection:
-    def test_detects_at_dispatch_macros(self, detector):
-        native_dir = PYTORCH_PATH / "aten/src/ATen/native"
-        if not native_dir.exists():
-            pytest.skip(f"Native directory not found: {native_dir}")
+        glob_pattern = anchor.get("glob", "*.cpp")
+        content_filter = anchor.get("content_filter", "AT_DISPATCH")
 
         found_binding = None
-        for cpp_file in list(native_dir.glob("*.cpp"))[:30]:
+        for cpp_file in sorted(scan_dir.glob(glob_pattern))[:30]:
             content = cpp_file.read_text(errors="replace")
-            if "AT_DISPATCH" not in content:
+            if content_filter not in content:
                 continue
-
             graph = detector.detect_bindings(str(cpp_file), content)
             at_dispatch = [
                 b
@@ -100,34 +192,23 @@ class TestAtDispatchDetection:
                 found_binding = at_dispatch[0]
                 break
 
-        assert found_binding is not None, "Should find AT_DISPATCH macros"
+        assert found_binding is not None, (
+            f"No AT_DISPATCH binding found in {anchor['dir']}"
+        )
         assert found_binding.cpp_name, (
-            "AT_DISPATCH binding must have a non-empty cpp_name"
+            f"AT_DISPATCH binding in {anchor['dir']} must have a non-empty cpp_name"
         )
 
-
-class TestDirectoryScan:
-    def test_scans_autograd_directory(self, detector):
-        scan_dir = PYTORCH_PATH / "torch/csrc/autograd"
+    def _check_has_binding_types(self, detector, source, anchor):
+        """Assert specific binding types are present in a directory scan."""
+        scan_dir = source / anchor["dir"]
         if not scan_dir.exists():
             pytest.skip(f"Directory not found: {scan_dir}")
 
         graph = detector.detect_bindings_in_directory(str(scan_dir))
-
         types = {b.binding_type for b in graph.bindings}
-        assert BindingType.PYBIND_METHOD.value in types, (
-            f"Expected pybind_method in autograd bindings, got types: {sorted(types)}"
-        )
 
-    def test_categorizes_bindings_by_type(self, detector):
-        scan_dir = PYTORCH_PATH / "torch/csrc/autograd"
-        if not scan_dir.exists():
-            pytest.skip(f"Directory not found: {scan_dir}")
-
-        graph = detector.detect_bindings_in_directory(str(scan_dir))
-
-        types = {b.binding_type for b in graph.bindings}
-        assert BindingType.PYBIND_METHOD.value in types
-        assert BindingType.TORCH_LIBRARY_IMPL.value in types, (
-            f"Expected both pybind and torch_library types, got: {sorted(types)}"
-        )
+        for expected_type in anchor["value"]:
+            assert expected_type in types, (
+                f"Expected {expected_type} in {anchor['dir']}, got: {sorted(types)}"
+            )

--- a/tests/test_binding_detector_pytorch.py
+++ b/tests/test_binding_detector_pytorch.py
@@ -28,10 +28,7 @@ def detector():
 
 
 class TestPybind11Detection:
-    """Tests for pybind11 pattern detection."""
-
     def test_detects_bindings_in_module_cpp(self, detector):
-        """Should detect pybind11 bindings in torch/csrc/Module.cpp."""
         test_file = PYTORCH_PATH / "torch/csrc/Module.cpp"
         if not test_file.exists():
             pytest.skip(f"Test file not found: {test_file}")
@@ -39,14 +36,14 @@ class TestPybind11Detection:
         content = test_file.read_text(errors="replace")
         graph = detector.detect_bindings(str(test_file), content)
 
-        assert len(graph.bindings) > 0, "Should find pybind11 bindings"
+        names = {b.python_name for b in graph.bindings if b.python_name}
+        assert "_WeakTensorRef" in names, (
+            f"Expected _WeakTensorRef in Module.cpp, got: {sorted(names)[:10]}"
+        )
 
 
 class TestTorchLibraryDetection:
-    """Tests for TORCH_LIBRARY pattern detection."""
-
     def test_detects_torch_library_in_rnn(self, detector):
-        """Should detect TORCH_LIBRARY bindings in RNN.cpp."""
         test_file = PYTORCH_PATH / "aten/src/ATen/native/RNN.cpp"
         if not test_file.exists():
             pytest.skip(f"Test file not found: {test_file}")
@@ -54,22 +51,19 @@ class TestTorchLibraryDetection:
         content = test_file.read_text(errors="replace")
         graph = detector.detect_bindings(str(test_file), content)
 
-        torch_lib_bindings = [
-            b for b in graph.bindings if "torch" in b.binding_type.lower()
-        ]
-        assert len(torch_lib_bindings) > 0, "Should find TORCH_LIBRARY bindings"
+        cpp_names = {b.cpp_name for b in graph.bindings if b.cpp_name}
+        assert "quantized_lstm" in cpp_names, (
+            f"Expected quantized_lstm in RNN.cpp bindings, got: {sorted(cpp_names)}"
+        )
 
 
 class TestCudaKernelDetection:
-    """Tests for CUDA kernel detection."""
-
     def test_detects_cuda_kernels(self, detector):
-        """Should detect __global__ CUDA kernels in .cu files."""
         cuda_dir = PYTORCH_PATH / "aten/src/ATen/native/cuda"
         if not cuda_dir.exists():
             pytest.skip(f"CUDA directory not found: {cuda_dir}")
 
-        found_kernels = False
+        found_kernel = None
         for cu_file in list(cuda_dir.glob("*.cu"))[:20]:
             content = cu_file.read_text(errors="replace")
             if "__global__" not in content:
@@ -77,22 +71,20 @@ class TestCudaKernelDetection:
 
             graph = detector.detect_bindings(str(cu_file), content)
             if graph.cuda_kernels:
-                found_kernels = True
+                found_kernel = graph.cuda_kernels[0]
                 break
 
-        assert found_kernels, "Should find CUDA kernels in at least one .cu file"
+        assert found_kernel is not None, "Should find a CUDA kernel in native/cuda/"
+        assert found_kernel.name, "Kernel must have a non-empty name"
 
 
 class TestAtDispatchDetection:
-    """Tests for AT_DISPATCH macro detection."""
-
     def test_detects_at_dispatch_macros(self, detector):
-        """Should detect AT_DISPATCH macros in native ops."""
         native_dir = PYTORCH_PATH / "aten/src/ATen/native"
         if not native_dir.exists():
             pytest.skip(f"Native directory not found: {native_dir}")
 
-        found_dispatch = False
+        found_binding = None
         for cpp_file in list(native_dir.glob("*.cpp"))[:30]:
             content = cpp_file.read_text(errors="replace")
             if "AT_DISPATCH" not in content:
@@ -105,35 +97,37 @@ class TestAtDispatchDetection:
                 if b.binding_type == BindingType.AT_DISPATCH.value
             ]
             if at_dispatch:
-                found_dispatch = True
+                found_binding = at_dispatch[0]
                 break
 
-        assert found_dispatch, "Should find AT_DISPATCH macros"
+        assert found_binding is not None, "Should find AT_DISPATCH macros"
+        assert found_binding.cpp_name, (
+            "AT_DISPATCH binding must have a non-empty cpp_name"
+        )
 
 
 class TestDirectoryScan:
-    """Tests for full directory scanning."""
-
     def test_scans_autograd_directory(self, detector):
-        """Should scan torch/csrc/autograd and find bindings."""
         scan_dir = PYTORCH_PATH / "torch/csrc/autograd"
         if not scan_dir.exists():
             pytest.skip(f"Directory not found: {scan_dir}")
 
         graph = detector.detect_bindings_in_directory(str(scan_dir))
 
-        assert len(graph.bindings) > 0, "Should find bindings in autograd directory"
+        types = {b.binding_type for b in graph.bindings}
+        assert BindingType.PYBIND_METHOD.value in types, (
+            f"Expected pybind_method in autograd bindings, got types: {sorted(types)}"
+        )
 
     def test_categorizes_bindings_by_type(self, detector):
-        """Should categorize bindings by their type."""
         scan_dir = PYTORCH_PATH / "torch/csrc/autograd"
         if not scan_dir.exists():
             pytest.skip(f"Directory not found: {scan_dir}")
 
         graph = detector.detect_bindings_in_directory(str(scan_dir))
 
-        by_type = {}
-        for b in graph.bindings:
-            by_type[b.binding_type] = by_type.get(b.binding_type, 0) + 1
-
-        assert len(by_type) > 1, "Should find multiple binding types"
+        types = {b.binding_type for b in graph.bindings}
+        assert BindingType.PYBIND_METHOD.value in types
+        assert BindingType.TORCH_LIBRARY_IMPL.value in types, (
+            f"Expected both pybind and torch_library types, got: {sorted(types)}"
+        )

--- a/tests/test_binding_detector_pytorch.py
+++ b/tests/test_binding_detector_pytorch.py
@@ -40,11 +40,10 @@ def _load_manifests() -> list[dict]:
 def _source_path(manifest: dict) -> Path | None:
     """Resolve source path from the manifest's env_var."""
     env_var = manifest.get("env_var", "")
-    for var in (env_var, f"{env_var}_PATH"):
-        if val := os.environ.get(var):
-            p = Path(val)
-            if p.exists():
-                return p
+    if val := os.environ.get(env_var):
+        p = Path(val)
+        if p.exists():
+            return p
     return None
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,106 @@
+"""Tests for the MCP server entry point (get_status, run_server)."""
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+
+from torchtalk import indexer
+from torchtalk.server import get_status, run_server
+
+
+@pytest.fixture
+def server_state(mock_state):
+    s = mock_state
+    s.bindings = [{"python_name": "add", "dispatch_key": "CPU"}]
+    s.native_functions = {"add": {"base_name": "add"}}
+    s.pytorch_source = "/fake/pytorch"
+    s.cpp_extractor = None
+    s.cpp_building = False
+    s.py_modules = {}
+    s.py_classes = {}
+    s.nn_modules = []
+    s.test_files = {}
+    s.test_classes = {}
+    s.test_functions = {}
+    s.opinfo_registry = {}
+    s.derivatives = {}
+    s.registrations = {}
+    indexer._build_indexes(s)
+    return s
+
+
+class TestGetStatus:
+    def test_shows_pytorch_source(self, server_state):
+        out = asyncio.run(get_status())
+        assert "/fake/pytorch" in out
+
+    def test_bindings_loaded(self, server_state):
+        out = asyncio.run(get_status())
+        assert "1 loaded" in out
+
+    def test_bindings_not_loaded(self, server_state):
+        server_state.bindings = []
+        indexer._build_indexes(server_state)
+        out = asyncio.run(get_status())
+        assert "Not loaded" in out
+
+    def test_cpp_building(self, server_state):
+        server_state.cpp_building = True
+        out = asyncio.run(get_status())
+        assert "Building" in out
+
+    def test_cpp_ready(self, server_state):
+        ext = MagicMock()
+        ext.get_call_graph_data.return_value = {
+            "stats": {"total_functions": 51000, "total_call_edges": 51000}
+        }
+        server_state.cpp_extractor = ext
+        out = asyncio.run(get_status())
+        assert "Ready" in out
+        assert "Functions: 51,000" in out
+
+    def test_cpp_unavailable_no_source(self, server_state):
+        server_state.pytorch_source = None
+        out = asyncio.run(get_status())
+        assert "Not available" in out
+
+    def test_python_modules_loaded(self, server_state):
+        server_state.py_modules = {"torch.nn.linear": MagicMock()}
+        server_state.py_classes = {"Linear": [MagicMock()]}
+        server_state.nn_modules = [MagicMock()]
+        out = asyncio.run(get_status())
+        assert "Modules: 1" in out
+
+    def test_test_infra_loaded(self, server_state):
+        server_state.test_files = {"test/test_x.py": {}}
+        server_state.test_classes = {"TestX": [{}]}
+        server_state.test_functions = {"test_foo": [{}]}
+        server_state.opinfo_registry = {"softmax": {}}
+        out = asyncio.run(get_status())
+        assert "Test files: 1" in out
+
+    def test_tools_table_ready_states(self, server_state):
+        out = asyncio.run(get_status())
+        assert "Ready" in out
+        assert "Not ready" in out
+
+
+class TestRunServer:
+    def test_starts_daemon_thread(self, monkeypatch):
+        captured = {}
+
+        class FakeThread:
+            def __init__(self, target, daemon):
+                captured["target"] = target
+                captured["daemon"] = daemon
+
+            def start(self):
+                pass
+
+        monkeypatch.setattr("torchtalk.server.mcp.run", lambda **kw: None)
+        monkeypatch.setattr("threading.Thread", FakeThread)
+
+        run_server(pytorch_source="/fake", transport="stdio")
+
+        assert captured["daemon"] is True


### PR DESCRIPTION
PR2 for #16

## Parametrized Integration Tests + CI

Addresses all review feedback.

**Integration tests restructured** (`test_binding_detector_pytorch.py`):
- Manifest-driven: `tests/integration/pytorch.yml` defines repo, ref, sparse paths, and anchor assertions
- Parametrized test loop — adding a new target (e.g. vllm) = one YAML file + one matrix entry
- `sorted()` on all globs for determinism, failure messages on every assert

**CI** (`.github/workflows/integration-tests.yml`):
- Workflow reads the manifest at runtime (repo, ref, sparse_paths, env_var) — manifest is single source of truth
- Matrix over targets — zero workflow edits to add a new target beyond appending to the list
- Pinned to release tag, path-gated + `workflow_dispatch`

**test_server.py** — no changes (clean from first round)

Note: `integration-tests.yml` is new in this PR and won't fire until merged. Will verify via `workflow_dispatch` post-merge.

653 -> 659 tests, 0 regressions.