### PR TITLE
Add unit tests for remaining untested tool-layer helpers.

### DIFF
--- a/tests/test_affected.py
+++ b/tests/test_affected.py
@@ -949,8 +949,6 @@ class TestApiSources:
             depth=1,
         )
         assert result["python_apis"] == ["foo"]
-        assert isinstance(result["python_apis"], list)
-        assert all(isinstance(a, str) for a in result["python_apis"])
 
 
 class TestFilenameFamily:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -2,6 +2,7 @@
 
 from torchtalk.analysis.helpers import (
     dedupe_by_key,
+    fuzzy_distance_limit,
     fuzzy_match,
     levenshtein_distance,
     safe_sort_key,
@@ -125,3 +126,22 @@ class TestDedupeByKey:
 
     def test_empty_list(self):
         assert dedupe_by_key([], "name") == []
+
+
+class TestFuzzyDistanceLimit:
+    def test_short_name_floor(self):
+        assert fuzzy_distance_limit("ab") == 2
+        assert fuzzy_distance_limit("relu") == 2
+
+    def test_medium_name_still_floor(self):
+        assert fuzzy_distance_limit("softmax") == 2
+
+    def test_long_enough_name_reaches_three(self):
+        assert fuzzy_distance_limit("hardswish") == 3
+
+    def test_long_kernel_name_capped_at_three(self):
+        assert fuzzy_distance_limit("very_long_kernel_name_here") == 3
+        assert fuzzy_distance_limit("a" * 40) == 3
+
+    def test_empty_name_uses_floor(self):
+        assert fuzzy_distance_limit("") == 2

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -1,22 +1,47 @@
-"""Tests for the modules list tool grouping."""
+"""Tests for the modules list and trace tools."""
 
 import asyncio
 from types import SimpleNamespace
 
 import pytest
 
-from torchtalk import indexer
-from torchtalk.tools.modules import _do_list_modules
+from torchtalk.tools.modules import _do_list_modules, _do_trace_module
 
 
 def _cls(name, qualified):
     return SimpleNamespace(name=name, qualified_name=qualified)
 
 
+def _method(name, signature="()"):
+    return SimpleNamespace(name=name, signature=signature)
+
+
+def _trace_cls(
+    name,
+    qualified,
+    *,
+    file_path="/src/torch/nn/modules/linear.py",
+    line_number=98,
+    bases=None,
+    is_module=False,
+    docstring=None,
+    methods=None,
+):
+    return SimpleNamespace(
+        name=name,
+        qualified_name=qualified,
+        file_path=file_path,
+        line_number=line_number,
+        bases=bases or [],
+        is_module=is_module,
+        docstring=docstring,
+        methods=methods or [],
+    )
+
+
 @pytest.fixture
-def module_state():
-    s = indexer._state
-    saved = (s.py_classes, s.nn_modules, s.bindings, s.native_functions)
+def module_state(mock_state):
+    s = mock_state
     s.bindings = [{"python_name": "x"}]
     s.native_functions = {}
     s.nn_modules = [
@@ -35,10 +60,68 @@ def module_state():
             for i in range(22)
         },
     }
-    try:
-        yield s
-    finally:
-        (s.py_classes, s.nn_modules, s.bindings, s.native_functions) = saved
+    return s
+
+
+@pytest.fixture
+def trace_module_state(mock_state):
+    s = mock_state
+    s.bindings = [{"python_name": "x"}]
+    s.native_functions = {}
+    s.pytorch_source = "/src"
+    linear = _trace_cls(
+        "Linear",
+        "torch.nn.Linear",
+        file_path="/src/torch/nn/modules/linear.py",
+        line_number=98,
+        bases=["Module"],
+        is_module=True,
+        docstring="Applies a linear transformation to the incoming data.",
+        methods=[
+            _method("forward", "(self, input)"),
+            _method("__init__", "(self, in_features, out_features)"),
+        ],
+    )
+    s.py_classes = {
+        "Linear": [linear],
+        "LinearReLU": [
+            _trace_cls(
+                "LinearReLU",
+                "torch.nn.intrinsic.LinearReLU",
+                file_path="/src/torch/nn/intrinsic/modules/fused.py",
+                line_number=12,
+                is_module=True,
+            )
+        ],
+        "AvgPool2d": [
+            _trace_cls(
+                "AvgPool2d",
+                "torch.nn.AvgPool2d",
+                file_path="/src/torch/nn/modules/pooling.py",
+                line_number=40,
+                is_module=True,
+            )
+        ],
+        "MaxPool2d": [
+            _trace_cls(
+                "MaxPool2d",
+                "torch.nn.MaxPool2d",
+                file_path="/src/torch/nn/modules/pooling.py",
+                line_number=80,
+                is_module=True,
+            )
+        ],
+        "SGD": [
+            _trace_cls(
+                "SGD",
+                "torch.optim.SGD",
+                file_path="/src/torch/optim/sgd.py",
+                line_number=5,
+                is_module=False,
+            )
+        ],
+    }
+    return s
 
 
 class TestNnGrouping:
@@ -58,3 +141,77 @@ class TestOptimListing:
     def test_non_optimizers_excluded(self, module_state):
         out = asyncio.run(_do_list_modules("optim"))
         assert "ArgMappingException" not in out
+
+
+class TestTraceModule:
+    def test_exact_match_renders_file_and_name(self, trace_module_state):
+        out = asyncio.run(_do_trace_module("Linear"))
+        assert "torch.nn.Linear" in out
+        assert "torch/nn/modules/linear.py:98" in out
+        assert "LinearReLU" not in out
+
+    def test_qualified_name_uses_last_segment(self, trace_module_state):
+        out = asyncio.run(_do_trace_module("torch.nn.Linear"))
+        assert "torch.nn.Linear" in out
+        assert "torch/nn/modules/linear.py:98" in out
+
+    def test_exact_match_beats_substring(self, trace_module_state):
+        out = asyncio.run(_do_trace_module("Linear"))
+        assert "torch.nn.Linear" in out
+        assert "Showing top match" not in out
+        assert "intrinsic.LinearReLU" not in out
+
+    def test_substring_fallback(self, trace_module_state):
+        out = asyncio.run(_do_trace_module("Pool"))
+        assert "AvgPool2d" in out or "MaxPool2d" in out
+        assert "Showing top match of 2 total" in out
+
+    def test_focus_full_includes_bases_type_docstring(self, trace_module_state):
+        out = asyncio.run(_do_trace_module("Linear", focus="full"))
+        assert "**Bases:** Module" in out
+        assert "**Type:** torch.nn.Module" in out
+        assert "Applies a linear transformation" in out
+
+    def test_default_focus_omits_full_metadata(self, trace_module_state):
+        out = asyncio.run(_do_trace_module("Linear"))
+        assert "**Methods:**" in out
+        assert "`forward(self, input)`" in out
+        assert "**Bases:**" not in out
+        assert "**Type:**" not in out
+        assert "Applies a linear transformation" not in out
+
+    def test_method_truncation(self, trace_module_state):
+        linear = trace_module_state.py_classes["Linear"][0]
+        linear.methods = [_method(f"m{i}", "()") for i in range(12)]
+        out = asyncio.run(_do_trace_module("Linear"))
+        assert "`m0()`" in out
+        assert "`m9()`" in out
+        assert "`m10()`" not in out
+        assert "... and 2 more" in out
+
+    def test_multiple_exact_matches_footer(self, trace_module_state):
+        extra = _trace_cls(
+            "Linear",
+            "torch.nn.modules.linear.Linear",
+            file_path="/src/torch/nn/modules/linear.py",
+            line_number=200,
+        )
+        trace_module_state.py_classes["Linear"].append(extra)
+        out = asyncio.run(_do_trace_module("Linear"))
+        assert "Showing top match of 2 total" in out
+
+    def test_not_found_with_similar_suggestion(self, trace_module_state):
+        out = asyncio.run(_do_trace_module("Linaer"))
+        assert "Module `Linaer` not found. Similar:" in out
+        assert "Linear" in out
+
+    def test_not_found_without_similar(self, trace_module_state):
+        out = asyncio.run(_do_trace_module("zzz_no_such_module_xyz"))
+        assert out == "Module `zzz_no_such_module_xyz` not found."
+
+    def test_python_analysis_unavailable(self, trace_module_state):
+        trace_module_state.py_classes = {}
+        out = asyncio.run(_do_trace_module("Linear"))
+        assert out == (
+            "Python module analysis not available. Ensure PyTorch source is loaded."
+        )

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -187,13 +187,11 @@ class TestGetNativeFunc:
         assert result["name"] == "relu"
 
     def test_case_insensitive_key(self, ops_state):
-        result = _get_native_func("softmax")
+        # Key and base_name differ, so only the key arm can match.
+        ops_state.native_functions["Foo_Bar"] = {"name": "Foo_Bar", "base_name": "zzz"}
+        result = _get_native_func("foo_bar")
         assert result is not None
-        assert result["name"] == "softmax"
-
-        result = _get_native_func("SOFTMAX")
-        assert result is not None
-        assert result["base_name"].lower() == "softmax"
+        assert result["name"] == "Foo_Bar"
 
     def test_base_name_fallback(self, ops_state):
         # Drop the exact "softmax" key so lookup walks to base_name.
@@ -236,13 +234,20 @@ class TestSimilarFunctions:
         assert long_key not in result
         assert short_key in result
 
-    def test_limit_and_unique(self, ops_state):
+    def test_dedups_key_matched_by_both_passes(self, ops_state):
+        # "softmaxx" matches on substring and again on levenshtein distance 1.
+        ops_state.native_functions["softmaxx"] = {
+            "name": "softmaxx",
+            "base_name": "softmaxx",
+        }
+        result = _similar_functions("softmax")
+        assert result.count("softmaxx") == 1
+
+    def test_limit(self, ops_state):
         for i in range(15):
             name = f"fn_{i:02d}"
             ops_state.native_functions[name] = {"name": name, "base_name": name}
-        result = _similar_functions("fn_", limit=3)
-        assert len(result) == 3
-        assert len(set(result)) == 3
+        assert len(_similar_functions("fn_", limit=3)) == 3
 
 
 class TestSearchBindings:

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -5,7 +5,13 @@ import asyncio
 import pytest
 
 from torchtalk import indexer
-from torchtalk.tools.ops import _do_cuda_kernels, trace
+from torchtalk.tools.ops import (
+    _do_cuda_kernels,
+    _do_search_bindings,
+    _get_native_func,
+    _similar_functions,
+    trace,
+)
 
 
 @pytest.fixture
@@ -60,7 +66,8 @@ class TestTraceWithoutCallGraph:
 
     def test_trace_unknown_function(self, state_without_call_graph):
         out = asyncio.run(trace("definitely_not_an_op_xyz"))
-        assert isinstance(out, str)
+        assert "definitely_not_an_op_xyz" in out
+        assert "not found" in out.lower()
 
 
 class TestCudaKernelsWithoutCallGraph:
@@ -104,3 +111,173 @@ class TestTraceFuzzyLabeling:
         out = asyncio.run(trace("hardswishh", focus="dispatch"))
         assert "fuzzy match" in out
         assert "Function Not Found" not in out
+
+
+@pytest.fixture
+def ops_state(mock_state):
+    s = mock_state
+    s.native_functions = {
+        "addmm": {"name": "addmm", "base_name": "addmm"},
+        "add_out": {"name": "add_out", "base_name": "add_out"},
+        "softmax.Tensor": {"name": "softmax.Tensor", "base_name": "softmax"},
+        "relu": {"name": "relu", "base_name": "relu"},
+        "softmin": {"name": "softmin", "base_name": "softmin"},
+        "softmax": {"name": "softmax", "base_name": "softmax"},
+    }
+    s.bindings = [
+        {
+            "python_name": "aten.add",
+            "cpp_name": "add_cpu",
+            "dispatch_key": "CPU",
+            "file_path": "/src/a.cpp",
+            "line_number": 10,
+        },
+        {
+            "python_name": "aten.add",
+            "cpp_name": "add_cuda",
+            "dispatch_key": "CUDA",
+            "file_path": "/src/b.cu",
+            "line_number": 20,
+        },
+        {
+            "python_name": "aten.add",
+            "cpp_name": "add_cpu",
+            "dispatch_key": "CPU",
+            "file_path": "/src/a_dup.cpp",
+            "line_number": 99,
+        },
+        {
+            "python_name": "aten.mul",
+            "cpp_name": "mul_cpu",
+            "dispatch_key": "CPU",
+            "file_path": "/src/c.cpp",
+            "line_number": 30,
+        },
+        {
+            "python_name": "aten.add",
+            "cpp_name": "add_mps",
+            "dispatch_key": "MPS",
+            "file_path": "/src/d.mm",
+            "line_number": 40,
+        },
+        {
+            "python_name": "aten.add",
+            "cpp_name": "add_quantized",
+            "dispatch_key": "QuantizedCPU",
+            "file_path": "/src/e.cpp",
+            "line_number": 50,
+        },
+        {
+            "python_name": "aten.add",
+            "cpp_name": "add_mkldnn",
+            "dispatch_key": "MkldnnCPU",
+            "file_path": "/src/f.cpp",
+            "line_number": 60,
+        },
+    ]
+    s.pytorch_source = "/src"
+    indexer._build_indexes(s)
+    return s
+
+
+class TestGetNativeFunc:
+    def test_exact_key(self, ops_state):
+        result = _get_native_func("relu")
+        assert result is not None
+        assert result["name"] == "relu"
+
+    def test_case_insensitive_key(self, ops_state):
+        result = _get_native_func("softmax")
+        assert result is not None
+        assert result["name"] == "softmax"
+
+        result = _get_native_func("SOFTMAX")
+        assert result is not None
+        assert result["base_name"].lower() == "softmax"
+
+    def test_base_name_fallback(self, ops_state):
+        # Drop the exact "softmax" key so lookup walks to base_name.
+        del ops_state.native_functions["softmax"]
+        result = _get_native_func("softmax")
+        assert result is not None
+        assert result["name"] == "softmax.Tensor"
+        assert result["base_name"] == "softmax"
+
+    def test_substring_shortest_key_wins(self, ops_state):
+        result = _get_native_func("add")
+        assert result is not None
+        assert result["name"] == "addmm"
+
+    def test_no_match_returns_none(self, ops_state):
+        assert _get_native_func("zzz_not_an_op") is None
+
+
+class TestSimilarFunctions:
+    def test_substring_suggestions(self, ops_state):
+        result = _similar_functions("soft")
+        assert "softmax" in result
+        assert "softmin" in result
+        assert "relu" not in result
+
+    def test_typo_via_levenshtein(self, ops_state):
+        result = _similar_functions("sofmax")
+        assert "softmax" in result
+
+    def test_skips_keys_of_length_fifty_or_more(self, ops_state):
+        long_key = "a" * 49 + "c"  # 50 chars — excluded by len(key) < 50
+        short_key = "a" * 47 + "b"
+        ops_state.native_functions[long_key] = {"name": long_key, "base_name": long_key}
+        ops_state.native_functions[short_key] = {
+            "name": short_key,
+            "base_name": short_key,
+        }
+        query = "a" * 47 + "x"
+        result = _similar_functions(query)
+        assert long_key not in result
+        assert short_key in result
+
+    def test_limit_and_unique(self, ops_state):
+        for i in range(15):
+            name = f"fn_{i:02d}"
+            ops_state.native_functions[name] = {"name": name, "base_name": name}
+        result = _similar_functions("fn_", limit=3)
+        assert len(result) == 3
+        assert len(set(result)) == 3
+
+
+class TestSearchBindings:
+    def test_matches_python_name(self, ops_state):
+        out = asyncio.run(_do_search_bindings("aten.add"))
+        assert "aten.add" in out
+        assert "add_cpu" in out
+        assert "aten.mul" not in out
+
+    def test_matches_cpp_name(self, ops_state):
+        out = asyncio.run(_do_search_bindings("add_cuda"))
+        assert "add_cuda" in out
+        assert "Found 1 binding(s)" in out
+        assert "add_cpu" not in out
+
+    def test_backend_filter(self, ops_state):
+        out = asyncio.run(_do_search_bindings("add", backend="CUDA"))
+        assert "(backend: CUDA)" in out
+        assert "add_cuda" in out
+        assert "add_cpu" not in out
+        assert "aten.mul" not in out
+
+    def test_dedup_by_name_and_dispatch_key(self, ops_state):
+        out = asyncio.run(_do_search_bindings("add_cpu"))
+        assert "Found 1 binding(s)" in out
+        assert "a_dup.cpp" not in out
+
+    def test_truncation_footer(self, ops_state):
+        out = asyncio.run(_do_search_bindings("add", limit=2))
+        assert "*Showing 2 of 5 results*" in out
+
+    def test_no_match_with_backend(self, ops_state):
+        out = asyncio.run(_do_search_bindings("gelu", backend="mps"))
+        assert out == "No bindings found matching 'gelu' with backend 'mps'."
+
+    def test_no_match_without_backend(self, ops_state):
+        out = asyncio.run(_do_search_bindings("gelu"))
+        assert out == "No bindings found matching 'gelu'."


### PR DESCRIPTION
Covers _do_trace_module matching and focus modes, binding search fallbacks, and fuzzy_distance_limit thresholds from RFC #16 PR3.

cc: @adabeyta 