### PR TITLE
Add manifest fields for framework-specific conventions

### DIFF
--- a/src/torchtalk/analysis/alias_map.py
+++ b/src/torchtalk/analysis/alias_map.py
@@ -34,8 +34,14 @@ def _exposed_name(base: str, strip: str) -> str:
     return base
 
 
-def build_function_alias_map(native_functions: dict[str, dict]) -> dict[str, str]:
+def build_function_alias_map(
+    native_functions: dict[str, dict],
+    op_namespaces: dict[str, str] | None = None,
+) -> dict[str, str]:
     """Map Python `torch.<...>` call forms to canonical `aten::<base>` symbols.
+
+    `op_namespaces` maps Python prefix → C++ namespace (manifest field);
+    defaults to `{"torch": "aten"}`. Every prefix pair emits its own entries.
 
     Default-namespace ops (no `python_module:`) emit `torch.<base>`. Ops with
     `python_module:` in `_NAMESPACE_RULES` emit a namespaced form (e.g.
@@ -44,6 +50,7 @@ def build_function_alias_map(native_functions: dict[str, dict]) -> dict[str, str
     """
     aliases: dict[str, str] = {}
     seen: set[str] = set()
+    namespaces = op_namespaces or {"torch": "aten"}
     for entry in native_functions.values():
         base = entry.get("base_name")
         if not base or base in seen:
@@ -60,7 +67,8 @@ def build_function_alias_map(native_functions: dict[str, dict]) -> dict[str, str
 
         pm = entry.get("python_module") or ""
         if not pm:
-            aliases[f"torch.{base}"] = f"aten::{base}"
+            for py, cpp in namespaces.items():
+                aliases[f"{py}.{base}"] = f"{cpp}::{base}"
             continue
 
         rule = _NAMESPACE_RULES.get(pm)
@@ -69,5 +77,6 @@ def build_function_alias_map(native_functions: dict[str, dict]) -> dict[str, str
         display, strip = rule
         exposed = _exposed_name(base, strip)
         if exposed:
-            aliases[f"torch.{display}.{exposed}"] = f"aten::{base}"
+            for py, cpp in namespaces.items():
+                aliases[f"{py}.{display}.{exposed}"] = f"{cpp}::{base}"
     return aliases

--- a/src/torchtalk/analysis/binding_detector.py
+++ b/src/torchtalk/analysis/binding_detector.py
@@ -97,16 +97,30 @@ _CPP_CONTROL_KEYWORDS = {
 _IMPL_WRAPPERS = ("TORCH_FN_BOXED", "TORCH_FN")
 _NO_IMPL_MARKERS = ("makeFallthrough", "makeNamedNotSupported")
 
-# `__global__` kernel definition. Allows leading `template <...>`,
-# `static`/`inline`, and `__launch_bounds__`/`C10_LAUNCH_BOUNDS_*` attributes
-# in either order around the keyword.
+# `__global__` kernel definition; attributes may flank the keyword.
+_KERNEL_ATTR = (
+    r"(?:"
+    r"(?:static|inline|__forceinline__)"
+    # call-like macro, e.g. `__launch_bounds__(512, VLLM_BLOCKS_PER_SM(512))`
+    r"|(?:[A-Za-z_]\w*)\s*\((?:[^()]|\([^()]*\))*\)"
+    r"|__[A-Za-z0-9_]+__"
+    r")(?:\s|//[^\n]*\n)+"  # separator may include a `//` comment line
+)
+_KERNEL_RETURN_TYPE = (
+    r"(?:typename\s+)?"
+    r"[A-Za-z_]\w*(?:::[A-Za-z_]\w*)*"
+    # template args may contain parens and comparisons, e.g. `<(width > 0) && ...>`
+    r"(?:\s*<(?:[^<>()]|\([^()]*\)|<[^<>]*>)*>)?"
+    r"(?:\s*[*&]+)?"
+)
 _KERNEL_PATTERN = re.compile(
     r"(?:template\s*<[^>]+>\s*)?"
-    r"(?:(?:static|inline|__forceinline__)\s+)*"
-    r"(?:(?:__launch_bounds__|C10_LAUNCH_BOUNDS_\d+)\s*\([^)]*\)\s*)*"
+    rf"(?:{_KERNEL_ATTR})*"
     r"__global__\s+"
-    r"(?:(?:static|inline|__forceinline__)\s+)*"
-    r"void\s+(\w+)(?:<([^>]+)>)?\s*\(([^)]*)\)"
+    rf"(?:{_KERNEL_ATTR})*"
+    rf"{_KERNEL_RETURN_TYPE}\s+"
+    rf"(?:{_KERNEL_ATTR})*"  # e.g. `void __launch_bounds__(256) name(...)`
+    r"(\w+)(?:<([^>]+)>)?\s*\(([^)]*)\)"
 )
 
 # `__device__` helper. CUDA helpers commonly stack `__host__ __device__`

--- a/src/torchtalk/analysis/binding_detector.py
+++ b/src/torchtalk/analysis/binding_detector.py
@@ -94,7 +94,8 @@ _CPP_CONTROL_KEYWORDS = {
     "sizeof",
 }
 
-_IMPL_WRAPPERS = ("TORCH_FN_BOXED", "TORCH_FN")
+# PyTorch defaults; overridden by `ConventionManifest.cpp_call_wrappers`.
+_IMPL_WRAPPERS = ("TORCH_FN_BOXED", "TORCH_FN", "TORCH_BOX", "TORCH_SELECTIVE_FN")
 _NO_IMPL_MARKERS = ("makeFallthrough", "makeNamedNotSupported")
 
 # `__global__` kernel definition; attributes may flank the keyword.
@@ -133,7 +134,9 @@ _DEVICE_PATTERN = re.compile(
 )
 
 
-def _clean_impl_target(raw: str, op_name: str = "") -> str:
+def _clean_impl_target(
+    raw: str, op_name: str = "", wrappers: tuple[str, ...] = _IMPL_WRAPPERS
+) -> str:
     """Extract a usable cpp_name from `m.impl("op", <raw>)`.
 
     Returns `op_name` as a fallback when `raw` is a no-real-impl marker
@@ -156,7 +159,8 @@ def _clean_impl_target(raw: str, op_name: str = "") -> str:
             return m.group(1).rsplit("::", 1)[-1]
         return op_name
 
-    for wrapper in _IMPL_WRAPPERS:
+    # Longest names first so `TORCH_FN_BOXED(` is not mistaken for `TORCH_FN(`.
+    for wrapper in sorted(wrappers, key=len, reverse=True):
         prefix = wrapper + "("
         if raw.startswith(prefix):
             raw = raw[len(prefix) :]
@@ -181,6 +185,7 @@ class BindingDetector:
         search_dirs: tuple[str, ...] | None = None,
         exclude_patterns: tuple[str, ...] | None = None,
         registration_macros: tuple[str, ...] | None = None,
+        call_wrappers: tuple[str, ...] | None = None,
     ):
         from tree_sitter_language_pack import get_parser
 
@@ -192,6 +197,7 @@ class BindingDetector:
         # Empty tuples fall back to the PyTorch defaults in patterns.py.
         self.exclude_patterns = exclude_patterns or ()
         self.registration_macros = registration_macros or ()
+        self.call_wrappers = call_wrappers or _IMPL_WRAPPERS
         log.info("BindingDetector initialized with C++/CUDA support")
 
     def _preprocess(self, content: str) -> str:
@@ -555,7 +561,9 @@ class BindingDetector:
             # Strip overload suffix (`abs.out` → `abs`) so cpp_name is searchable
             # via the bare op name when raw target is a no-impl marker.
             bare_op = op_name.split(".", 1)[0]
-            cpp_func = _clean_impl_target(match.group(2), op_name=bare_op)
+            cpp_func = _clean_impl_target(
+                match.group(2), op_name=bare_op, wrappers=self.call_wrappers
+            )
             if not cpp_func:
                 continue
             line_offset = block_content[: match.start()].count("\n")

--- a/src/torchtalk/analysis/decomp_aliases.py
+++ b/src/torchtalk/analysis/decomp_aliases.py
@@ -16,6 +16,7 @@ from pathlib import Path
 
 log = logging.getLogger(__name__)
 
+# PyTorch defaults; overridden by `ConventionManifest.decomp_alias_paths`.
 _DECOMP_FILES = (
     "torch/_decomp/decompositions.py",
     "torch/_decomp/decompositions_for_jvp.py",
@@ -26,6 +27,7 @@ _DECOMP_FILES = (
     "torch/_refs/nn/functional/__init__.py",
     "torch/_refs/special/__init__.py",
 )
+_DEFAULT_NAMESPACES = ("aten",)
 
 
 def _is_register_decomp(node: ast.expr) -> bool:
@@ -36,20 +38,24 @@ def _is_register_decomp(node: ast.expr) -> bool:
     return False
 
 
-def _aten_op_name(attr: ast.expr) -> str | None:
+def _aten_op_name(
+    attr: ast.expr, namespaces: tuple[str, ...] = _DEFAULT_NAMESPACES
+) -> str | None:
     """`aten.X` → `X`; `aten.X.default` → `X`; anything else → None."""
     parts: list[str] = []
     node: ast.expr = attr
     while isinstance(node, ast.Attribute):
         parts.append(node.attr)
         node = node.value
-    if isinstance(node, ast.Name) and node.id == "aten" and parts:
+    if isinstance(node, ast.Name) and node.id in namespaces and parts:
         parts.reverse()
         return parts[0]
     return None
 
 
-def _aten_ops_from_args(args: list[ast.expr]) -> list[str]:
+def _aten_ops_from_args(
+    args: list[ast.expr], namespaces: tuple[str, ...] = _DEFAULT_NAMESPACES
+) -> list[str]:
     """Pull aten op names out of register_decomposition() args.
 
     Accepts `aten.X`, `aten.X.default`, `[aten.X, aten.Y]`, `(aten.X, aten.Y)`.
@@ -60,13 +66,25 @@ def _aten_ops_from_args(args: list[ast.expr]) -> list[str]:
         node = queue.pop()
         if isinstance(node, ast.List | ast.Tuple):
             queue.extend(node.elts)
-        elif isinstance(node, ast.Attribute) and (name := _aten_op_name(node)):
+        elif isinstance(node, ast.Attribute) and (
+            name := _aten_op_name(node, namespaces)
+        ):
             out.append(name)
     return out
 
 
-def extract_decomp_aliases(source: Path) -> dict[str, list[str]]:
-    """Walk decomp/refs files; return bidirectional aten ↔ python-fn alias map."""
+def extract_decomp_aliases(
+    source: Path,
+    paths: tuple[str, ...] = (),
+    namespaces: tuple[str, ...] = (),
+) -> dict[str, list[str]]:
+    """Walk decomp/refs files; return bidirectional aten ↔ python-fn alias map.
+
+    `paths` / `namespaces` come from the manifest; empty falls back to the
+    PyTorch defaults.
+    """
+    paths = paths or _DECOMP_FILES
+    namespaces = namespaces or _DEFAULT_NAMESPACES
     aliases: dict[str, set[str]] = {}
 
     def link(a: str, b: str) -> None:
@@ -75,7 +93,7 @@ def extract_decomp_aliases(source: Path) -> dict[str, list[str]]:
         aliases.setdefault(a, set()).add(b)
         aliases.setdefault(b, set()).add(a)
 
-    for rel in _DECOMP_FILES:
+    for rel in paths:
         path = source / rel
         if not path.exists():
             continue
@@ -92,7 +110,7 @@ def extract_decomp_aliases(source: Path) -> dict[str, list[str]]:
                     continue
                 if not _is_register_decomp(deco.func):
                     continue
-                for op_name in _aten_ops_from_args(deco.args):
+                for op_name in _aten_ops_from_args(deco.args, namespaces):
                     link(op_name, node.name)
 
     return {k: sorted(v) for k, v in aliases.items()}

--- a/src/torchtalk/analysis/dispatch_stub_map.py
+++ b/src/torchtalk/analysis/dispatch_stub_map.py
@@ -26,6 +26,7 @@ log = logging.getLogger(__name__)
 # ALSO_REGISTER_AVX512_DISPATCH, REGISTER_NO_AVX2_DISPATCH, etc.
 _REGISTER_RE = re.compile(r"\b(?:ALSO_)?REGISTER_\w+\s*\(\s*(\w+)\s*,\s*&?\s*(\w+)")
 
+_DEFAULT_STUB_ROOT = "aten/src/ATen/native"
 _SCAN_DIRS = ("cpu", "cuda", "quantized/cpu", "quantized/cuda")
 _SCAN_EXTS = ("*.cpp", "*.cu", "*.h")
 _STUB_SUFFIXES = ("_stub", "_kernel_impl", "_kernel")
@@ -52,13 +53,19 @@ def _stub_to_op(stub: str, nf_keys: set[str]) -> str | None:
 
 
 def extract_kernel_impl_to_op(
-    source: Path, native_functions: dict[str, dict] | None
+    source: Path,
+    native_functions: dict[str, dict] | None,
+    stub_root: str = "",
 ) -> dict[str, str]:
-    """Build kernel-impl → ATen op map by scraping REGISTER_* macros."""
+    """Build kernel-impl → ATen op map by scraping REGISTER_* macros.
+
+    `stub_root` is the repo-relative dir holding the cpu/cuda kernel subdirs
+    (manifest `dispatch_stub_root`); empty falls back to the PyTorch path.
+    """
     if not native_functions:
         return {}
     nf_keys = set(native_functions)
-    native_root = source / "aten" / "src" / "ATen" / "native"
+    native_root = source / (stub_root or _DEFAULT_STUB_ROOT)
     if not native_root.exists():
         return {}
 

--- a/src/torchtalk/harness.py
+++ b/src/torchtalk/harness.py
@@ -61,6 +61,14 @@ class ConventionManifest:
     registration_calls: tuple[CallRegistration, ...] = ()
     # dispatcher call → arg (position or kwarg) naming the invoked method
     string_dispatchers: dict[str, int | str] = field(default_factory=dict)
+    # Python op prefix → C++ op namespace, e.g. `torch.add` ↔ `aten::add`.
+    op_namespaces: dict[str, str] = field(default_factory=dict)
+    # Repo-relative files scanned for `@register_decomposition(<ns>.X)`.
+    decomp_alias_paths: tuple[str, ...] = ()
+    # Repo-relative dir whose cpu/cuda subdirs hold REGISTER_*_DISPATCH macros.
+    dispatch_stub_root: str = ""
+    # Wrappers stripped from `m.impl("op", WRAPPER(fn))` targets.
+    cpp_call_wrappers: tuple[str, ...] = ()
 
 
 @runtime_checkable
@@ -83,6 +91,19 @@ PYTORCH_MANIFEST = ConventionManifest(
     native_functions_yaml="aten/src/ATen/native/native_functions.yaml",
     derivatives_yaml="tools/autograd/derivatives.yaml",
     decorator_registries={"register_decomposition": "decompositions"},
+    op_namespaces={"torch": "aten"},
+    decomp_alias_paths=(
+        "torch/_decomp/decompositions.py",
+        "torch/_decomp/decompositions_for_jvp.py",
+        "torch/_refs/__init__.py",
+        "torch/_refs/_conversions.py",
+        "torch/_refs/fft.py",
+        "torch/_refs/linalg/__init__.py",
+        "torch/_refs/nn/functional/__init__.py",
+        "torch/_refs/special/__init__.py",
+    ),
+    dispatch_stub_root="aten/src/ATen/native",
+    cpp_call_wrappers=("TORCH_FN_BOXED", "TORCH_FN", "TORCH_BOX", "TORCH_SELECTIVE_FN"),
 )
 
 

--- a/src/torchtalk/indexer.py
+++ b/src/torchtalk/indexer.py
@@ -443,6 +443,7 @@ def _build_index(
         search_dirs=manifest.cpp_search_dirs,
         exclude_patterns=manifest.exclude_patterns,
         registration_macros=manifest.registration_macros,
+        call_wrappers=manifest.cpp_call_wrappers or None,
     )
     graph = detector.detect_bindings_in_directory(source)
 
@@ -635,7 +636,9 @@ def _init_python_modules(source: str):
         from .analysis.alias_map import build_function_alias_map
         from .analysis.python_analyzer import PythonAnalyzer, build_module_index
 
-        _state.alias_map = build_function_alias_map(_state.native_functions)
+        _state.alias_map = build_function_alias_map(
+            _state.native_functions, active_manifest().op_namespaces or None
+        )
         log.info(f"Alias map: {len(_state.alias_map)} torch.<op> aliases")
 
         manifest = active_manifest()
@@ -777,7 +780,12 @@ def _init_decomp_aliases(source: str):
     """Build aten ↔ python-fn alias map from decomp/refs decorators."""
     from .analysis.decomp_aliases import extract_decomp_aliases
 
-    _state.decomp_alias_map = extract_decomp_aliases(Path(source))
+    manifest = active_manifest()
+    _state.decomp_alias_map = extract_decomp_aliases(
+        Path(source),
+        paths=manifest.decomp_alias_paths,
+        namespaces=tuple(manifest.op_namespaces.values()),
+    )
     log.info(f"Decomp aliases: {len(_state.decomp_alias_map)} entries")
 
 
@@ -794,7 +802,9 @@ def _init_dispatch_stubs(source: str):
     from .analysis.dispatch_stub_map import extract_kernel_impl_to_op
 
     _state.kernel_impl_to_op = extract_kernel_impl_to_op(
-        Path(source), _state.native_functions
+        Path(source),
+        _state.native_functions,
+        stub_root=active_manifest().dispatch_stub_root,
     )
     log.info(f"Dispatch stub map: {len(_state.kernel_impl_to_op)} kernel impls")
 

--- a/tests/test_alias_map.py
+++ b/tests/test_alias_map.py
@@ -202,3 +202,10 @@ class TestBuildFunctionAliasMap:
             }
         }
         assert build_function_alias_map(native) == {"torch.x": "aten::x"}
+
+
+def test_custom_op_namespaces():
+    nf = {"add": {"base_name": "add", "variants": "function", "python_module": ""}}
+    assert build_function_alias_map(nf, {"vllm": "_C"}) == {"vllm.add": "_C::add"}
+    both = build_function_alias_map(nf, {"torch": "aten", "vllm": "_C"})
+    assert both == {"torch.add": "aten::add", "vllm.add": "_C::add"}

--- a/tests/test_binding_detector.py
+++ b/tests/test_binding_detector.py
@@ -481,3 +481,24 @@ class TestManifestExcludeAndPrefilter:
         assert detector.detect_bindings_in_directory(str(repo)).bindings == []
         fallback = BindingDetector(search_dirs=("csrc",))
         assert fallback.detect_bindings_in_directory(str(repo)).bindings
+
+
+class TestCallWrappers:
+    def test_default_wrappers_include_box_and_selective(self):
+        assert _clean_impl_target("TORCH_BOX(&foo)") == "foo"
+        assert _clean_impl_target("TORCH_SELECTIVE_FN(ns::bar)") == "bar"
+
+    def test_custom_wrappers_override_defaults(self):
+        assert _clean_impl_target("MY_WRAP(foo)", wrappers=("MY_WRAP",)) == "foo"
+        assert _clean_impl_target("TORCH_FN(foo)", wrappers=("MY_WRAP",)) != "foo"
+
+    def test_detector_passes_wrappers(self):
+        src = """
+        TORCH_LIBRARY_IMPL(aten, CPU, m) {
+            m.impl("relu", MY_WRAP(relu_kernel));
+        }
+        """
+        graph = BindingDetector(call_wrappers=("MY_WRAP",)).detect_bindings(
+            "ops.cpp", src
+        )
+        assert "relu_kernel" in {b.cpp_name for b in graph.bindings}

--- a/tests/test_binding_detector.py
+++ b/tests/test_binding_detector.py
@@ -162,6 +162,55 @@ class TestKernelPattern:
     def test_skips_non_kernel_function(self):
         assert self._name("void notKernel(int* a) {") is None
 
+    def test_launch_bounds_after_global(self):
+        code = "__global__ void __launch_bounds__(256) after_kernel(float* x) {"
+        assert self._name(code) == "after_kernel"
+
+    def test_bare_macro_attribute_after_global(self):
+        code = (
+            "__global__ __quickreduce_launch_bounds_two_shot__ static void\n"
+            "allreduce_prototype_twoshot(T const* A, T* B, uint32_t N) {"
+        )
+        assert self._name(code) == "allreduce_prototype_twoshot"
+
+    def test_non_void_template_return_type(self):
+        code = (
+            "template <typename scalar_t, int width>\n"
+            "__global__ std::enable_if_t<(width > 0) && _typeConvert<scalar_t>::exists>"
+            "\n"
+            "fused_add_rms_norm_kernel(scalar_t* __restrict__ input, float epsilon) {"
+        )
+        assert self._name(code) == "fused_add_rms_norm_kernel"
+
+    def test_call_like_macro_and_launch_bounds_after_global(self):
+        code = (
+            "template <typename T>\n"
+            "__global__ void __launch_bounds__(1024, 1) MY_ATTR(x)\n"
+            "stacked_kernel(T* a) {"
+        )
+        assert self._name(code) == "stacked_kernel"
+
+    def test_nested_parens_in_launch_bounds(self):
+        code = (
+            "template <class Type, bool UE8M0_SF = false>\n"
+            "__global__ void __launch_bounds__(512, VLLM_BLOCKS_PER_SM(512))\n"
+            "cvt_fp16_to_fp4(int32_t numRows, Type const* in) {"
+        )
+        assert self._name(code) == "cvt_fp16_to_fp4"
+
+    def test_line_comment_between_attribute_and_name(self):
+        code = (
+            "__global__ void __launch_bounds__(32 * warps_per_block, blocks_per_sm)\n"
+            "// a is column major, b is row major\n"
+            "hadamard_transform_kernel(b16* a, b16* out, int total_num_chunks) {"
+        )
+        assert self._name(code) == "hadamard_transform_kernel"
+
+    def test_launch_bounds_is_never_a_kernel_name(self):
+        code = "__global__ void __launch_bounds__(512) real_name(int* a) {"
+        names = [m.group(1) for m in _KERNEL_PATTERN.finditer(code)]
+        assert names == ["real_name"]
+
 
 class TestDevicePattern:
     def _name(self, code: str) -> str | None:

--- a/tests/test_decomp_aliases.py
+++ b/tests/test_decomp_aliases.py
@@ -160,3 +160,16 @@ class TestExtractDecompAliases:
         )
         out = extract_decomp_aliases(tmp_path)
         assert out["conv_op"] == ["conv_decomp"]
+
+
+def test_custom_paths_and_namespace(tmp_path):
+    f = tmp_path / "pkg" / "decomps.py"
+    f.parent.mkdir(parents=True)
+    f.write_text(
+        "@register_decomposition(myops.foo)\ndef foo_decomp(x):\n    return x\n"
+    )
+    assert extract_decomp_aliases(tmp_path) == {}
+    aliases = extract_decomp_aliases(
+        tmp_path, paths=("pkg/decomps.py",), namespaces=("myops",)
+    )
+    assert aliases == {"foo": ["foo_decomp"], "foo_decomp": ["foo"]}

--- a/tests/test_dispatch_stub_map.py
+++ b/tests/test_dispatch_stub_map.py
@@ -199,3 +199,14 @@ class TestKernelTuHelperMapping:
         nf = {f"op{i}": {} for i in range(6)}
         out = extract_kernel_impl_to_op(tmp_path, nf)
         assert "shared_helper" not in out
+
+
+def test_custom_stub_root(tmp_path):
+    root = tmp_path / "csrc" / "kernels"
+    (root / "cpu").mkdir(parents=True)
+    (root / "cpu" / "Foo.cpp").write_text("REGISTER_DISPATCH(foo_stub, &foo_kernel);\n")
+    nf = {"foo": {"name": "foo"}}
+    assert extract_kernel_impl_to_op(tmp_path, nf) == {}
+    assert extract_kernel_impl_to_op(tmp_path, nf, stub_root="csrc/kernels") == {
+        "foo_kernel": "foo"
+    }

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -77,3 +77,19 @@ class TestCachePathsHarnessQualified:
         assert all("pytorch" in p.name for p in pytorch_paths.values())
         for key, path in pytorch_paths.items():
             assert path != vllm_paths[key]
+
+
+class TestManifestOpFields:
+    def test_pytorch_defaults(self):
+        m = PYTORCH_MANIFEST
+        assert m.op_namespaces == {"torch": "aten"}
+        assert "torch/_decomp/decompositions.py" in m.decomp_alias_paths
+        assert m.dispatch_stub_root == "aten/src/ATen/native"
+        assert "TORCH_BOX" in m.cpp_call_wrappers
+
+    def test_empty_by_default(self):
+        m = ConventionManifest(package="x", cpp_search_dirs=("csrc",))
+        assert m.op_namespaces == {}
+        assert m.decomp_alias_paths == ()
+        assert m.dispatch_stub_root == ""
+        assert m.cpp_call_wrappers == ()


### PR DESCRIPTION
Adds op_namespaces, decomp_alias_paths, dispatch_stub_root, and cpp_call_wrappers to ConventionManifest so detectors read conventions from the manifest instead of hardcoding PyTorch's.