### PR TITLE
Load harness manifests from TOML

### DIFF
--- a/scripts/harness_smoke.py
+++ b/scripts/harness_smoke.py
@@ -1,7 +1,8 @@
 """Harness smoke test: validates that a harness config indexes a real repo.
 
 Reads repo/ref/sparse_paths from tests/integration/<target>.yml (single
-source of truth). Thresholds live here since they're smoke-specific.
+source of truth). Thresholds come from `expected_minimums` in the harness
+manifest (src/torchtalk/manifests/<target>.toml).
 
 Usage:
     python scripts/harness_smoke.py --harness pytorch --source /path/to/pytorch
@@ -19,21 +20,12 @@ from pathlib import Path
 
 import yaml
 
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+from torchtalk.harness import get_harness, list_harnesses
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 MANIFESTS_DIR = REPO_ROOT / "tests" / "integration"
 
-SMOKE_THRESHOLDS = {
-    "pytorch": {
-        # Thresholds: min across v2.10-v2.13 sparse-clone results minus
-        # 10% buffer. Absorbs restructures like the v2.13 native_functions
-        # drop (2869->2762) without false alarms.
-        "min_native_functions": 2400,
-        "min_bindings": 2100,
-        "min_cuda_kernels": 450,
-        "min_derivatives": 600,
-        "min_python_modules": 100,
-    },
-}
 
 _STABLE_TAG = re.compile(r"^v(\d+)\.(\d+)\.(\d+)$")
 
@@ -97,7 +89,9 @@ def sparse_clone(repo_url: str, ref: str, paths: list[str], dest: Path) -> None:
 
 
 def main():
-    targets = sorted(SMOKE_THRESHOLDS.keys())
+    targets = sorted(
+        n for n in list_harnesses() if get_harness(n).manifest.expected_minimums
+    )
     parser = argparse.ArgumentParser(description="Harness smoke test")
     parser.add_argument("--harness", required=True, choices=targets)
     group = parser.add_mutually_exclusive_group(required=True)
@@ -119,10 +113,10 @@ def main():
     else:
         stats = _run_index(args.harness, args.source)
 
-    thresholds = SMOKE_THRESHOLDS[args.harness]
+    thresholds = get_harness(args.harness).manifest.expected_minimums
     failures = []
     for key, threshold in thresholds.items():
-        field = key.removeprefix("min_")
+        field = key
         actual = stats.get(field, 0)
         print(f"  {field}: {actual} (threshold: >= {threshold})")
         if actual < threshold:

--- a/src/torchtalk/cli.py
+++ b/src/torchtalk/cli.py
@@ -219,6 +219,21 @@ def cmd_mcp_serve(args):
     return 0
 
 
+def _apply_repo_manifest(source: str, explicit_harness: str | None) -> None:
+    """Prefer a `.torchtalk.toml` shipped in the checkout unless --harness was given."""
+    from torchtalk.harness import ManifestError, activate_repo_manifest
+
+    if explicit_harness:
+        return
+    try:
+        name = activate_repo_manifest(source)
+    except ManifestError as e:
+        log.warning("Ignoring repo manifest: %s", e)
+        return
+    if name:
+        log.info("Using repo-local manifest .torchtalk.toml (harness %r)", name)
+
+
 def cmd_index_build(args):
     """Build or refresh the index for a source checkout and exit."""
     from torchtalk.config import resolve_source
@@ -230,6 +245,7 @@ def cmd_index_build(args):
     if not source:
         log.error("No source configured. Run 'torchtalk init' first.")
         return 1
+    _apply_repo_manifest(source, args.harness)
 
     stats = build_index(source, wait_for_cpp=not args.no_wait)
 
@@ -259,6 +275,7 @@ def cmd_index_update(args):
     if not source:
         log.error("No source configured. Run 'torchtalk init' first.")
         return 1
+    _apply_repo_manifest(source, args.harness)
 
     try:
         stats = update_index(source, since=args.since, on_uncovered=args.on_uncovered)

--- a/src/torchtalk/harness.py
+++ b/src/torchtalk/harness.py
@@ -7,18 +7,15 @@ from different manifests merge via package-qualified symbol IDs (symbols.py).
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-from typing import Protocol, runtime_checkable
+import sys
+from dataclasses import dataclass, field, fields
+from pathlib import Path
+from typing import Any, Protocol, runtime_checkable
 
-from .analysis.patterns import (
-    CPP_BINDING_PATTERNS,
-    CPP_SEARCH_DIRS,
-    EXCLUDE_PATTERNS,
-    PYTHON_SEARCH_DIRS,
-    TEST_CONTENT_PATTERNS,
-    TEST_SEARCH_DIRS,
-    TEST_UTILITY_MODULES,
-)
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
 
 
 @dataclass(frozen=True)
@@ -69,6 +66,10 @@ class ConventionManifest:
     dispatch_stub_root: str = ""
     # Wrappers stripped from `m.impl("op", WRAPPER(fn))` targets.
     cpp_call_wrappers: tuple[str, ...] = ()
+    # Harness names this package's symbols resolve against (bridge targets).
+    depends_on: tuple[str, ...] = ()
+    # Smoke-test floors: index stat name → minimum count (scripts/harness_smoke.py).
+    expected_minimums: dict[str, int] = field(default_factory=dict)
 
 
 @runtime_checkable
@@ -78,33 +79,159 @@ class Harness(Protocol):
     manifest: ConventionManifest
 
 
-PYTORCH_MANIFEST = ConventionManifest(
-    package="pytorch",
-    cpp_search_dirs=tuple(CPP_SEARCH_DIRS),
-    python_search_dirs=tuple(PYTHON_SEARCH_DIRS),
-    python_package_roots=("torch",),
-    test_search_dirs=tuple(TEST_SEARCH_DIRS),
-    test_content_patterns=tuple(TEST_CONTENT_PATTERNS),
-    test_utility_modules=tuple(TEST_UTILITY_MODULES),
-    exclude_patterns=tuple(EXCLUDE_PATTERNS),
-    registration_macros=tuple(CPP_BINDING_PATTERNS),
-    native_functions_yaml="aten/src/ATen/native/native_functions.yaml",
-    derivatives_yaml="tools/autograd/derivatives.yaml",
-    decorator_registries={"register_decomposition": "decompositions"},
-    op_namespaces={"torch": "aten"},
-    decomp_alias_paths=(
-        "torch/_decomp/decompositions.py",
-        "torch/_decomp/decompositions_for_jvp.py",
-        "torch/_refs/__init__.py",
-        "torch/_refs/_conversions.py",
-        "torch/_refs/fft.py",
-        "torch/_refs/linalg/__init__.py",
-        "torch/_refs/nn/functional/__init__.py",
-        "torch/_refs/special/__init__.py",
-    ),
-    dispatch_stub_root="aten/src/ATen/native",
-    cpp_call_wrappers=("TORCH_FN_BOXED", "TORCH_FN", "TORCH_BOX", "TORCH_SELECTIVE_FN"),
-)
+MANIFESTS_DIR = Path(__file__).parent / "manifests"
+REPO_MANIFEST_NAME = ".torchtalk.toml"
+
+# Each TOML section key maps to one ConventionManifest field; `cpp.*` keys
+# are prefixed to their field names below.
+_SECTION_FIELDS: dict[str, dict[str, str]] = {
+    "paths": {
+        f: f
+        for f in (
+            "cpp_search_dirs",
+            "python_search_dirs",
+            "python_package_roots",
+            "test_search_dirs",
+            "test_content_patterns",
+            "test_utility_modules",
+            "exclude_patterns",
+            "native_functions_yaml",
+            "derivatives_yaml",
+            "decomp_alias_paths",
+            "dispatch_stub_root",
+        )
+    },
+    "cpp": {
+        "registration_macros": "registration_macros",
+        "macro_aliases": "cpp_macro_aliases",
+        "token_map": "cpp_token_map",
+        "call_wrappers": "cpp_call_wrappers",
+    },
+    "python": {
+        f: f
+        for f in (
+            "decorator_registries",
+            "string_registries",
+            "registration_calls",
+            "string_dispatchers",
+            "op_namespaces",
+        )
+    },
+}
+_FIELD_TYPES = {f.name: f.type for f in fields(ConventionManifest)}
+
+
+class ManifestError(ValueError):
+    """A manifest TOML file is malformed or references an unknown profile."""
+
+
+def _flatten(data: dict[str, Any], origin: str) -> dict[str, Any]:
+    """Map TOML sections onto ConventionManifest field names."""
+    out: dict[str, Any] = {}
+    pkg = data.get("package", {})
+    if "name" in pkg:
+        out["package"] = pkg["name"]
+    if "depends_on" in pkg:
+        out["depends_on"] = pkg["depends_on"]
+    for section, mapping in _SECTION_FIELDS.items():
+        for key, value in data.get(section, {}).items():
+            if key not in mapping:
+                raise ManifestError(f"{origin}: unknown key [{section}] {key}")
+            out[mapping[key]] = value
+    if "expected_minimums" in data:
+        out["expected_minimums"] = data["expected_minimums"]
+    known = {"package", "paths", "cpp", "python", "expected_minimums"}
+    for section in data:
+        if section not in known:
+            raise ManifestError(f"{origin}: unknown section [{section}]")
+    return out
+
+
+def _coerce(name: str, value: Any) -> Any:
+    """Convert TOML values to the field's dataclass type (lists → tuples)."""
+    if name == "registration_calls":
+        return tuple(
+            CallRegistration(
+                r["call"], r["key_arg"], r["target_arg"], r.get("registry", "")
+            )
+            for r in value
+        )
+    ftype = str(_FIELD_TYPES[name])
+    if ftype.startswith("tuple") and isinstance(value, list):
+        return tuple(value)
+    return value
+
+
+def manifest_from_dict(
+    data: dict[str, Any],
+    *,
+    base: ConventionManifest | None = None,
+    origin: str = "<dict>",
+) -> ConventionManifest:
+    """Build a manifest from parsed TOML, layered over `base` when given.
+
+    Every key set in `data` replaces the base value outright (lists and
+    tables are not merged), so a profile can drop a base default by
+    setting it to an empty value.
+    """
+    values: dict[str, Any] = {}
+    if base is not None:
+        values.update({f.name: getattr(base, f.name) for f in fields(base)})
+    for name, raw in _flatten(data, origin).items():
+        values[name] = _coerce(name, raw)
+    if "package" not in values:
+        raise ManifestError(f"{origin}: [package] name is required")
+    if "cpp_search_dirs" not in values:
+        raise ManifestError(f"{origin}: [paths] cpp_search_dirs is required")
+    return ConventionManifest(**values)
+
+
+def _read_toml(path: Path) -> dict[str, Any]:
+    with open(path, "rb") as f:
+        return tomllib.load(f)
+
+
+def load_manifest(path: str | Path, _seen: tuple[str, ...] = ()) -> ConventionManifest:
+    """Load a manifest TOML file, resolving `[package] extends` recursively.
+
+    `extends` names a built-in profile in `torchtalk/manifests/` (e.g.
+    "torch-extension" or "pytorch") or a path relative to the file itself.
+    """
+    path = Path(path)
+    if not path.exists():
+        raise ManifestError(f"Manifest not found: {path}")
+    data = _read_toml(path)
+    origin = str(path)
+    if origin in _seen:
+        raise ManifestError(f"{origin}: circular extends chain {(*_seen, origin)}")
+    base = None
+    parent = data.get("package", {}).get("extends")
+    if parent:
+        builtin = MANIFESTS_DIR / f"{parent}.toml"
+        candidate = builtin if builtin.exists() else path.parent / parent
+        if not candidate.exists():
+            raise ManifestError(f"{origin}: extends {parent!r} not found")
+        base = load_manifest(candidate, (*_seen, origin))
+    return manifest_from_dict(data, base=base, origin=origin)
+
+
+def load_builtin_manifest(name: str) -> ConventionManifest:
+    """Load `torchtalk/manifests/<name>.toml`."""
+    return load_manifest(MANIFESTS_DIR / f"{name}.toml")
+
+
+def builtin_manifest_names() -> list[str]:
+    """Names of shipped manifest profiles (including abstract bases)."""
+    return sorted(p.stem for p in MANIFESTS_DIR.glob("*.toml"))
+
+
+def find_repo_manifest(source: str | Path) -> Path | None:
+    """Return `<source>/.torchtalk.toml` when the checkout ships one."""
+    path = Path(source) / REPO_MANIFEST_NAME
+    return path if path.is_file() else None
+
+
+PYTORCH_MANIFEST = load_builtin_manifest("pytorch")
 
 
 @dataclass(frozen=True)
@@ -117,52 +244,8 @@ class ManifestHarness:
 PYTORCH_HARNESS = ManifestHarness(PYTORCH_MANIFEST)
 
 
-VLLM_MANIFEST = ConventionManifest(
-    package="vllm",
-    cpp_search_dirs=("csrc",),
-    python_search_dirs=("vllm",),
-    python_package_roots=("vllm",),
-    test_search_dirs=("tests",),
-    exclude_patterns=("/tests/", "/benchmarks/", "/examples/", "__pycache__"),
-    cpp_macro_aliases={
-        "TORCH_LIBRARY_EXPAND": "TORCH_LIBRARY",
-        "TORCH_LIBRARY_IMPL_EXPAND": "TORCH_LIBRARY_IMPL",
-    },
-    cpp_token_map={"TORCH_EXTENSION_NAME": "_C"},
-    decorator_registries={"CustomOp.register": "custom_ops"},
-    string_registries=(
-        "_TEXT_GENERATION_MODELS",
-        "_EMBEDDING_MODELS",
-        "_LATE_INTERACTION_MODELS",
-        "_REWARD_MODELS",
-        "_TOKEN_CLASSIFICATION_MODELS",
-        "_SEQUENCE_CLASSIFICATION_MODELS",
-        "_MULTIMODAL_MODELS",
-        "_SPECULATIVE_DECODING_MODELS",
-        "_TRANSFORMERS_SUPPORTED_MODELS",
-        "_TRANSFORMERS_BACKEND_MODELS",
-    ),
-    registration_calls=(
-        CallRegistration(
-            "direct_register_custom_op", "op_name", "op_func", "custom_ops"
-        ),
-        CallRegistration("direct_register_custom_op", 0, 1, "custom_ops"),
-    ),
-    string_dispatchers={"collective_rpc": 0},
-)
-
-TORCHVISION_MANIFEST = ConventionManifest(
-    package="torchvision",
-    cpp_search_dirs=("torchvision/csrc",),
-    python_search_dirs=("torchvision",),
-    python_package_roots=("torchvision",),
-    test_search_dirs=("test",),
-    exclude_patterns=tuple(EXCLUDE_PATTERNS),
-    cpp_macro_aliases={
-        "STABLE_TORCH_LIBRARY_FRAGMENT": "TORCH_LIBRARY_FRAGMENT",
-        "STABLE_TORCH_LIBRARY_IMPL": "TORCH_LIBRARY_IMPL",
-    },
-)
+VLLM_MANIFEST = load_builtin_manifest("vllm")
+TORCHVISION_MANIFEST = load_builtin_manifest("torchvision")
 
 _REGISTRY: dict[str, Harness] = {}
 _ACTIVE = "pytorch"
@@ -171,6 +254,11 @@ _ACTIVE = "pytorch"
 def register_harness(name: str, harness: Harness) -> None:
     """Register a harness under a package name."""
     _REGISTRY[name] = harness
+
+
+def list_harnesses() -> list[str]:
+    """Names of all registered harnesses."""
+    return sorted(_REGISTRY)
 
 
 def get_harness(name: str | None = None) -> Harness:
@@ -196,6 +284,22 @@ def active_harness_name() -> str:
 
 def active_manifest() -> ConventionManifest:
     return get_harness().manifest
+
+
+def activate_repo_manifest(source: str | Path) -> str | None:
+    """Register and activate `<source>/.torchtalk.toml` if present.
+
+    Returns the harness name activated, or None when the checkout has no
+    repo-local manifest. Re-registering an existing name replaces it, so a
+    checkout can override a shipped profile of the same package.
+    """
+    path = find_repo_manifest(source)
+    if path is None:
+        return None
+    manifest = load_manifest(path)
+    register_harness(manifest.package, ManifestHarness(manifest))
+    set_active_harness(manifest.package)
+    return manifest.package
 
 
 register_harness("pytorch", PYTORCH_HARNESS)

--- a/src/torchtalk/manifests/pytorch.toml
+++ b/src/torchtalk/manifests/pytorch.toml
@@ -1,0 +1,119 @@
+# PyTorch (pytorch/pytorch). Lists here mirror torchtalk/analysis/patterns.py;
+# tests/test_harness.py fails if they drift.
+# expected_minimums: min across v2.10-v2.13 sparse-clone results minus 10%.
+
+[package]
+name = "pytorch"
+
+[paths]
+cpp_search_dirs = [
+    "aten/src/ATen/native",
+    "torch/csrc",
+    "c10",
+    "aten/src/ATen/core",
+    "aten/src/ATen/cuda",
+]
+python_search_dirs = [
+    "torch/nn",
+    "torch/optim",
+    "torch/autograd",
+    "torch/jit",
+    "torch/cuda",
+    "torch/backends",
+    "torch/fx",
+    "torch/_dynamo",
+    "torch/_inductor",
+    "torch/_decomp",
+    "torch/ao",
+    "torch/distributed",
+    "torch/export",
+    "torch/_refs",
+    "torch/_prims",
+    "torch/nested",
+    "torch/mps",
+]
+python_package_roots = [
+    "torch",
+]
+test_search_dirs = [
+    "test",
+    "torch/testing",
+    "torch/testing/_internal",
+]
+test_content_patterns = [
+    "TestCase",
+    "pytest",
+    "instantiate_device_type_tests",
+    "OpInfo",
+    "make_tensor",
+    "assert_close",
+    "dtype_test",
+    "gradcheck",
+]
+test_utility_modules = [
+    "torch/testing/_internal/common_utils.py",
+    "torch/testing/_internal/common_device_type.py",
+    "torch/testing/_internal/common_dtype.py",
+    "torch/testing/_internal/common_cuda.py",
+    "torch/testing/_internal/opinfo/core.py",
+    "torch/testing/_internal/opinfo/definitions.py",
+    "torch/testing/_internal/hypothesis_utils.py",
+    "torch/testing/_comparison.py",
+]
+exclude_patterns = [
+    "/test/",
+    "/tests/",
+    "test_",
+    "_test.",
+    "/third_party/",
+    "/generated/",
+    "/build/",
+    "__pycache__",
+    "/benchmarks/",
+    "/examples/",
+]
+native_functions_yaml = "aten/src/ATen/native/native_functions.yaml"
+derivatives_yaml = "tools/autograd/derivatives.yaml"
+decomp_alias_paths = [
+    "torch/_decomp/decompositions.py",
+    "torch/_refs/__init__.py",
+    "torch/_refs/nn/functional/__init__.py",
+    "torch/_refs/linalg/__init__.py",
+    "torch/_refs/special/__init__.py",
+    "torch/_refs/fft.py",
+    "torch/_prims/__init__.py",
+    "torch/_decomp/decompositions_for_rng.py",
+]
+dispatch_stub_root = "aten/src/ATen/native"
+
+[cpp]
+registration_macros = [
+    "TORCH_LIBRARY",
+    "PYBIND11_MODULE",
+    "pybind11",
+    "py::class_<",
+    "m.def(",
+    "__global__",
+    "AT_DISPATCH",
+    "c10::Dispatcher",
+    "RegisterOperators",
+]
+call_wrappers = [
+    "TORCH_BOX",
+    "TORCH_SELECTIVE_FN",
+    "TORCH_FN",
+    "TORCH_SELECTIVE_SCHEMA",
+]
+
+[python.decorator_registries]
+register_decomposition = "decompositions"
+
+[python.op_namespaces]
+torch = "aten"
+
+[expected_minimums]
+native_functions = 2400
+bindings = 2100
+cuda_kernels = 450
+derivatives = 600
+python_modules = 100

--- a/src/torchtalk/manifests/torch-extension.toml
+++ b/src/torchtalk/manifests/torch-extension.toml
@@ -1,0 +1,57 @@
+# Abstract base profile for repos that extend PyTorch (custom ops, kernels).
+# Not registered as a harness; use `extends = "torch-extension"`.
+
+[package]
+name = "torch-extension"
+depends_on = [
+    "pytorch",
+]
+
+[paths]
+cpp_search_dirs = [
+    "csrc",
+]
+python_search_dirs = []
+python_package_roots = []
+test_search_dirs = [
+    "tests",
+]
+test_content_patterns = [
+    "TestCase",
+    "pytest",
+    "unittest",
+]
+exclude_patterns = [
+    "/test/",
+    "/tests/",
+    "test_",
+    "_test.",
+    "/third_party/",
+    "/generated/",
+    "/build/",
+    "__pycache__",
+    "/benchmarks/",
+    "/examples/",
+]
+
+[cpp]
+registration_macros = [
+    "TORCH_LIBRARY",
+    "PYBIND11_MODULE",
+    "pybind11",
+    "py::class_<",
+    "m.def(",
+    "__global__",
+    "AT_DISPATCH",
+    "c10::Dispatcher",
+    "RegisterOperators",
+]
+call_wrappers = [
+    "TORCH_BOX",
+    "TORCH_SELECTIVE_FN",
+    "TORCH_FN",
+    "TORCH_SELECTIVE_SCHEMA",
+]
+
+[python.op_namespaces]
+torch = "aten"

--- a/src/torchtalk/manifests/torchvision.toml
+++ b/src/torchtalk/manifests/torchvision.toml
@@ -1,0 +1,23 @@
+# torchvision (pytorch/vision). Delta over torch-extension.
+
+[package]
+name = "torchvision"
+extends = "torch-extension"
+
+[paths]
+cpp_search_dirs = [
+    "torchvision/csrc",
+]
+python_search_dirs = [
+    "torchvision",
+]
+python_package_roots = [
+    "torchvision",
+]
+test_search_dirs = [
+    "test",
+]
+
+[cpp.macro_aliases]
+STABLE_TORCH_LIBRARY_FRAGMENT = "TORCH_LIBRARY_FRAGMENT"
+STABLE_TORCH_LIBRARY_IMPL = "TORCH_LIBRARY_IMPL"

--- a/src/torchtalk/manifests/vllm.toml
+++ b/src/torchtalk/manifests/vllm.toml
@@ -1,0 +1,58 @@
+# vLLM (vllm-project/vllm). Delta over torch-extension.
+
+[package]
+name = "vllm"
+extends = "torch-extension"
+
+[paths]
+python_search_dirs = [
+    "vllm",
+]
+python_package_roots = [
+    "vllm",
+]
+exclude_patterns = [
+    "/tests/",
+    "/benchmarks/",
+    "/examples/",
+    "__pycache__",
+]
+
+[cpp.macro_aliases]
+TORCH_LIBRARY_EXPAND = "TORCH_LIBRARY"
+TORCH_LIBRARY_IMPL_EXPAND = "TORCH_LIBRARY_IMPL"
+
+[cpp.token_map]
+TORCH_EXTENSION_NAME = "_C"
+
+[python]
+string_registries = [
+    "_TEXT_GENERATION_MODELS",
+    "_EMBEDDING_MODELS",
+    "_LATE_INTERACTION_MODELS",
+    "_REWARD_MODELS",
+    "_TOKEN_CLASSIFICATION_MODELS",
+    "_SEQUENCE_CLASSIFICATION_MODELS",
+    "_MULTIMODAL_MODELS",
+    "_SPECULATIVE_DECODING_MODELS",
+    "_TRANSFORMERS_SUPPORTED_MODELS",
+    "_TRANSFORMERS_BACKEND_MODELS",
+]
+
+[python.decorator_registries]
+"CustomOp.register" = "custom_ops"
+
+[python.string_dispatchers]
+collective_rpc = 0
+
+[[python.registration_calls]]
+call = "direct_register_custom_op"
+key_arg = "op_name"
+target_arg = "op_func"
+registry = "custom_ops"
+
+[[python.registration_calls]]
+call = "direct_register_custom_op"
+key_arg = 0
+target_arg = 1
+registry = "custom_ops"

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -93,3 +93,101 @@ class TestManifestOpFields:
         assert m.decomp_alias_paths == ()
         assert m.dispatch_stub_root == ""
         assert m.cpp_call_wrappers == ()
+
+
+class TestTomlManifests:
+    """PR-3: manifests load from TOML with extends/depends_on/expected_minimums."""
+
+    def test_builtins_registered_from_toml(self):
+        assert harness_mod.get_harness("pytorch").manifest is PYTORCH_MANIFEST
+        assert PYTORCH_MANIFEST.package == "pytorch"
+        assert harness_mod.get_harness("vllm").manifest.package == "vllm"
+        assert harness_mod.get_harness("torchvision").manifest.package == "torchvision"
+        assert "torch-extension" in harness_mod.builtin_manifest_names()
+        assert "torch-extension" not in harness_mod.list_harnesses()
+
+    def test_pytorch_toml_matches_patterns_constants(self):
+        from torchtalk.analysis import patterns as P
+
+        m = PYTORCH_MANIFEST
+        assert m.cpp_search_dirs == tuple(P.CPP_SEARCH_DIRS)
+        assert m.python_search_dirs == tuple(P.PYTHON_SEARCH_DIRS)
+        assert m.test_search_dirs == tuple(P.TEST_SEARCH_DIRS)
+        assert m.test_content_patterns == tuple(P.TEST_CONTENT_PATTERNS)
+        assert m.test_utility_modules == tuple(P.TEST_UTILITY_MODULES)
+        assert m.exclude_patterns == tuple(P.EXCLUDE_PATTERNS)
+        assert m.registration_macros == tuple(P.CPP_BINDING_PATTERNS)
+
+    def test_pytorch_expected_minimums(self):
+        assert PYTORCH_MANIFEST.expected_minimums["native_functions"] == 2400
+        assert PYTORCH_MANIFEST.depends_on == ()
+
+    def test_vllm_extends_torch_extension(self):
+        m = harness_mod.VLLM_MANIFEST
+        base = harness_mod.load_builtin_manifest("torch-extension")
+        assert m.depends_on == ("pytorch",)
+        assert m.cpp_search_dirs == base.cpp_search_dirs == ("csrc",)
+        assert m.cpp_call_wrappers == base.cpp_call_wrappers
+        assert m.op_namespaces == {"torch": "aten"}
+        # child replaces, not appends
+        expected = ("/tests/", "/benchmarks/", "/examples/", "__pycache__")
+        assert m.exclude_patterns == expected
+        assert m.cpp_macro_aliases["TORCH_LIBRARY_EXPAND"] == "TORCH_LIBRARY"
+        assert m.registration_calls[0].call == "direct_register_custom_op"
+        assert m.registration_calls[1].key_arg == 0
+        assert m.string_dispatchers == {"collective_rpc": 0}
+        assert len(m.string_registries) == 10
+
+    def test_extends_replaces_not_appends(self, tmp_path):
+        child = tmp_path / "child.toml"
+        child.write_text(
+            '[package]\nname = "x"\nextends = "torch-extension"\n'
+            '[paths]\nexclude_patterns = ["/only/"]\n'
+            "[cpp]\ncall_wrappers = []\n"
+            "[expected_minimums]\nbindings = 5\n"
+        )
+        m = harness_mod.load_manifest(child)
+        assert m.exclude_patterns == ("/only/",)
+        assert m.cpp_call_wrappers == ()
+        assert m.depends_on == ("pytorch",)
+        assert m.expected_minimums == {"bindings": 5}
+
+    def test_extends_relative_path_and_cycle(self, tmp_path):
+        (tmp_path / "base.toml").write_text(
+            '[package]\nname = "b"\n[paths]\ncpp_search_dirs = ["src"]\n'
+        )
+        (tmp_path / "leaf.toml").write_text(
+            '[package]\nname = "leaf"\nextends = "base.toml"\n'
+        )
+        leaf = harness_mod.load_manifest(tmp_path / "leaf.toml")
+        assert leaf.cpp_search_dirs == ("src",)
+        (tmp_path / "a.toml").write_text('[package]\nname = "a"\nextends = "b.toml"\n')
+        (tmp_path / "b.toml").write_text('[package]\nname = "b"\nextends = "a.toml"\n')
+        with pytest.raises(harness_mod.ManifestError, match="circular"):
+            harness_mod.load_manifest(tmp_path / "a.toml")
+
+    def test_unknown_key_and_missing_required(self, tmp_path):
+        bad = tmp_path / "bad.toml"
+        bad.write_text('[package]\nname = "x"\n[paths]\nbogus = 1\n')
+        with pytest.raises(harness_mod.ManifestError, match="unknown key"):
+            harness_mod.load_manifest(bad)
+        bad.write_text('[package]\nname = "x"\n')
+        with pytest.raises(harness_mod.ManifestError, match="cpp_search_dirs"):
+            harness_mod.load_manifest(bad)
+        with pytest.raises(harness_mod.ManifestError, match="not found"):
+            harness_mod.load_manifest(tmp_path / "nope.toml")
+
+    def test_repo_local_manifest_activates(self, tmp_path):
+        prev = harness_mod.active_harness_name()
+        (tmp_path / ".torchtalk.toml").write_text(
+            '[package]\nname = "myext"\nextends = "torch-extension"\n'
+        )
+        try:
+            assert harness_mod.find_repo_manifest(tmp_path) is not None
+            assert harness_mod.activate_repo_manifest(tmp_path) == "myext"
+            assert harness_mod.active_harness_name() == "myext"
+            assert harness_mod.active_manifest().cpp_search_dirs == ("csrc",)
+        finally:
+            harness_mod.set_active_harness(prev)
+            harness_mod._REGISTRY.pop("myext", None)
+        assert harness_mod.activate_repo_manifest(tmp_path / "empty") is None


### PR DESCRIPTION
Moves manifests to src/torchtalk/manifests/*.toml with extends (tuples replace, not append), depends_on, and expected_minimums, plus repo-local .torchtalk.toml auto-activation in index build/update. Adds a torch-extension abstract base profile; smoke tests read minimums from the manifest instead of hardcoded thresholds. The frozen dataclass and validation stay only the source of truth moves to files.