### PR TITLE
Add ExternalRef primitive and import edges

### DIFF
--- a/docs/bridge-design.md
+++ b/docs/bridge-design.md
@@ -1,0 +1,101 @@
+# Bridge design: cross-package references
+
+TorchTalk indexes one package at a time (PyTorch, vLLM, torchvision, ...).
+The *bridge* connects two indexed packages so questions like "which vLLM
+kernels call this ATen op?" or "what breaks in vLLM if `torch.nn.Module`
+changes?" can be answered from static analysis alone.
+
+This document fixes the data model. Phase C (`Workspace`, resolvers, cross
+tools) builds on it; PR-4 ships the primitive and the cheapest edge.
+
+## One primitive: `ExternalRef`
+
+```python
+@dataclass(frozen=True)
+class ExternalRef:
+    from_symbol: str   # qualified symbol in the *referencing* package
+    to_name: str       # name as written ("torch.nn.Module", "at::empty")
+    kind: str          # import | op | cpp | base_class | provides | version_pin
+    evidence: str      # "path:line" — always points at real source
+    confidence: float  # 1.0 for syntactic facts, lower for heuristics
+    to_package: str    # harness name this ref resolves against ("pytorch")
+```
+
+`to_package` is an addition to the five-field sketch from the design notes:
+collection already knows which `depends_on` entry a name belongs to, and
+recording it saves the resolver a second lookup.
+
+A bridge is then simply: for every `ExternalRef` in package A whose
+`to_package == B`, look up `to_name` in B's symbol table. Unresolved refs
+are kept (they are the "vLLM uses a symbol PyTorch no longer exports"
+signal), not dropped.
+
+## Kinds and their resolvers
+
+| kind          | collected from                                   | resolver list (manifest)      | status |
+|---------------|--------------------------------------------------|-------------------------------|--------|
+| `import`      | module-level `import` / `from ... import`         | `python_package_roots` of dep | PR-4   |
+| `op`          | `torch.ops.aten.X`, `torch.X` calls               | `[python] op_namespaces`      | C2     |
+| `cpp`         | `at::X`, `c10::X` in C++ sources                  | `[bridge] cpp_namespaces`     | C2     |
+| `base_class`  | `class Foo(torch.nn.Module)`                      | `[bridge] base_class_namespaces` | C2  |
+| `provides`    | `TORCH_LIBRARY` / `register_op` registrations     | (direction flipped: this package *defines* `to_name`) | C2 |
+| `version_pin` | `requirements*.txt`, `pyproject.toml`             | none — package-level edge     | C2     |
+
+Everything is a manifest list, not code: adding a framework means listing
+which namespaces belong to its dependency, never adding a new edge class.
+
+### Why imports first
+
+Import edges are pure syntax, already parsed by `PythonAnalyzer`, and exist
+in every Python package. They give the bridge a smoke test on day one
+(`external_refs > 0` for vLLM) and a coarse dependency map (which vLLM
+modules touch `torch.distributed` vs `torch.nn`) before any resolver exists.
+
+### Direction
+
+Refs always point *out* of the package being indexed. A registration
+(`kind="provides"`) is the same record with the meaning flipped: vLLM
+*provides* `_C::rms_norm` into the `torch.ops` namespace. The Workspace
+joins A's `provides` with B's `op` refs to answer "who implements this".
+
+## Manifest fields
+
+```toml
+[package]
+depends_on = ["pytorch"]          # bridge targets, in resolution order
+
+[python.op_namespaces]
+torch = "aten"                    # torch.X  -> aten::X
+
+[bridge]
+cpp_namespaces = ["at", "c10", "torch"]
+base_class_namespaces = ["torch.nn", "torch.autograd", "torch.optim"]
+```
+
+`torch-extension.toml` carries these, so every extension profile inherits
+them via `extends`.
+
+## What is deliberately skipped
+
+- **dynamo / `torch.compile` decorators** — runtime behaviour, no static
+  target symbol.
+- **Attribute chains through aliases** (`F = torch.nn.functional; F.relu`)
+  — resolved later by the existing `alias_map`, not by the collector.
+- **Third parties not in `depends_on`** (`numpy`, `triton`) — no symbol
+  table to resolve against; listing them would only add noise.
+
+## Storage
+
+Python analysis is not cached in the JSON index (it runs at load), so
+external refs live in `ServerState.external_refs` as plain dicts and are
+recomputed per load. They are exposed through `get_stats()` as
+`external_refs`. The snapshot schema (v3) is untouched; resolved bridge
+results get their own cache and a v4 schema in C2.
+
+## Roadmap
+
+- **PR-4 (this):** `ExternalRef`, `collect_import_refs`, `[bridge]` fields,
+  stats + CLI count.
+- **C1:** `Workspace` holding N packages; tools take `package=`.
+- **C2:** op/cpp/base_class/provides resolvers, version-pin edge,
+  `bridge(symbol)`, `trace`/`affected --across`, bridge cache + snapshot v4.

--- a/src/torchtalk/analysis/external_refs.py
+++ b/src/torchtalk/analysis/external_refs.py
@@ -1,0 +1,140 @@
+"""Cross-package references: the single edge primitive for the bridge.
+
+An `ExternalRef` records one place where a symbol in the active package
+names something that lives in another package (a dependency listed in the
+manifest's `depends_on`). The bridge (phase C) resolves these against the
+target package's symbol table; this module only *collects* them.
+
+Kinds (see docs/bridge-design.md):
+  import      module-level `import torch.nn` / `from torch import nn`
+  op          `torch.ops.aten.X` / `torch.X` op reference (resolver: op_namespaces)
+  cpp         `at::X` / `c10::X` C++ symbol (resolver: cpp_namespaces)
+  base_class  `class Foo(torch.nn.Module)` (resolver: base_class_namespaces)
+  provides    registration flipped: this package *defines* `to_name`
+  version_pin package-level pin from requirements/pyproject
+
+PR-4 ships `import` edges only; the other kinds are collected in C2.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import asdict, dataclass
+from typing import Any
+
+from torchtalk.harness import (
+    ConventionManifest,
+    ManifestError,
+    get_harness,
+    load_builtin_manifest,
+)
+
+REF_KINDS = ("import", "op", "cpp", "base_class", "provides", "version_pin")
+
+
+@dataclass(frozen=True)
+class ExternalRef:
+    """One outgoing reference from this package into a dependency."""
+
+    from_symbol: str  # qualified symbol in this package (module name for imports)
+    to_name: str  # name as written, e.g. "torch.nn.Module"
+    kind: str  # one of REF_KINDS
+    evidence: str  # "path:line"
+    confidence: float = 1.0
+    to_package: str = ""  # harness name the ref should resolve against, if known
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def bridge_targets(manifest: ConventionManifest) -> dict[str, tuple[str, ...]]:
+    """Map each `depends_on` harness name → its Python package roots.
+
+    Uses the registered harness when one is active for that name, else the
+    shipped TOML profile. Unknown names are skipped (the manifest check in
+    B6 reports them); the bridge is best-effort by design.
+    """
+    targets: dict[str, tuple[str, ...]] = {}
+    for dep in manifest.depends_on:
+        try:
+            dep_manifest = get_harness(dep).manifest
+        except KeyError:
+            try:
+                dep_manifest = load_builtin_manifest(dep)
+            except ManifestError:
+                continue
+        roots = tuple(dep_manifest.python_package_roots)
+        if roots:
+            targets[dep] = roots
+    return targets
+
+
+def _package_for(name: str, targets: dict[str, tuple[str, ...]]) -> str | None:
+    head = name.split(".", 1)[0]
+    for pkg, roots in targets.items():
+        if head in roots:
+            return pkg
+    return None
+
+
+def _import_target(imp: Any) -> str | None:
+    """Dotted name an import statement refers to; None for relative imports."""
+    module = imp.module or ""
+    if not module:
+        return None  # relative import (`from . import x`) — package-internal
+    if imp.name and imp.name != module and imp.name != "*":
+        return f"{module}.{imp.name}"
+    return module
+
+
+def collect_import_refs(
+    modules: dict[str, Any],
+    manifest: ConventionManifest,
+    targets: dict[str, tuple[str, ...]] | None = None,
+) -> list[ExternalRef]:
+    """Module-level import edges from `modules` into `depends_on` packages.
+
+    Each `PyImport` whose top-level package is a dependency root becomes one
+    `ExternalRef(kind="import")`. Imports of the active package itself and
+    of third parties not in `depends_on` are ignored. Deterministic order:
+    by module name, then line, then target.
+    """
+    if targets is None:
+        targets = bridge_targets(manifest)
+    if not targets:
+        return []
+    own_roots = set(manifest.python_package_roots)
+    refs: list[ExternalRef] = []
+    for mod_name in sorted(modules):
+        mod = modules[mod_name]
+        seen: set[tuple[str, int]] = set()
+        for imp in getattr(mod, "imports", ()):
+            target = _import_target(imp)
+            if target is None or target.split(".", 1)[0] in own_roots:
+                continue
+            pkg = _package_for(target, targets)
+            if pkg is None:
+                continue
+            key = (target, imp.line_number)
+            if key in seen:
+                continue
+            seen.add(key)
+            refs.append(
+                ExternalRef(
+                    from_symbol=mod_name,
+                    to_name=target,
+                    kind="import",
+                    evidence=f"{imp.file_path}:{imp.line_number}",
+                    to_package=pkg,
+                )
+            )
+    refs.sort(key=lambda r: (r.from_symbol, r.evidence, r.to_name))
+    return refs
+
+
+def refs_by_target(refs: Iterable[ExternalRef]) -> dict[str, list[ExternalRef]]:
+    """Group refs by `to_name` — the shape the bridge resolver consumes."""
+    out: dict[str, list[ExternalRef]] = {}
+    for r in refs:
+        out.setdefault(r.to_name, []).append(r)
+    return out

--- a/src/torchtalk/cli.py
+++ b/src/torchtalk/cli.py
@@ -255,6 +255,7 @@ def cmd_index_build(args):
     print(f"  Native functions: {stats['native_functions']:,}")
     print(f"  Python modules:   {stats['python_modules']:,}")
     print(f"  nn.Module classes:{stats['nn_modules']:>8,}")
+    print(f"  External refs:    {stats.get('external_refs', 0):,}")
     print(f"  Test files:       {stats['test_files']:,}")
     if stats["call_graph_building"]:
         print("  C++ call graph:   building in background")

--- a/src/torchtalk/harness.py
+++ b/src/torchtalk/harness.py
@@ -68,6 +68,10 @@ class ConventionManifest:
     cpp_call_wrappers: tuple[str, ...] = ()
     # Harness names this package's symbols resolve against (bridge targets).
     depends_on: tuple[str, ...] = ()
+    # [bridge] resolver lists: C++ namespaces owned by a dependency (`at::`),
+    # and base-class prefixes marking cross-package subclassing (`torch.nn`).
+    cpp_namespaces: tuple[str, ...] = ()
+    base_class_namespaces: tuple[str, ...] = ()
     # Smoke-test floors: index stat name → minimum count (scripts/harness_smoke.py).
     expected_minimums: dict[str, int] = field(default_factory=dict)
 
@@ -117,6 +121,10 @@ _SECTION_FIELDS: dict[str, dict[str, str]] = {
             "op_namespaces",
         )
     },
+    "bridge": {
+        "cpp_namespaces": "cpp_namespaces",
+        "base_class_namespaces": "base_class_namespaces",
+    },
 }
 _FIELD_TYPES = {f.name: f.type for f in fields(ConventionManifest)}
 
@@ -140,7 +148,7 @@ def _flatten(data: dict[str, Any], origin: str) -> dict[str, Any]:
             out[mapping[key]] = value
     if "expected_minimums" in data:
         out["expected_minimums"] = data["expected_minimums"]
-    known = {"package", "paths", "cpp", "python", "expected_minimums"}
+    known = {"package", "paths", "cpp", "python", "bridge", "expected_minimums"}
     for section in data:
         if section not in known:
             raise ManifestError(f"{origin}: unknown section [{section}]")

--- a/src/torchtalk/indexer.py
+++ b/src/torchtalk/indexer.py
@@ -56,6 +56,8 @@ class ServerState:
     nn_modules: list[Any] = field(default_factory=list)
     py_to_cpp_edges: dict[str, list[dict]] = field(default_factory=dict)
     alias_map: dict[str, str] = field(default_factory=dict)
+    # Outgoing cross-package refs (analysis/external_refs.py), as dicts.
+    external_refs: list[dict] = field(default_factory=list)
 
     test_files: dict[str, dict] = field(default_factory=dict)
     test_classes: dict[str, list[dict]] = field(default_factory=dict)
@@ -671,8 +673,26 @@ def _init_python_modules(source: str):
                 f"{len(_state.nn_modules)} nn.Module classes"
             )
             _init_py_cpp_edges(source)
+            _init_external_refs(all_modules, manifest)
     except Exception as e:
         log.warning(f"Failed to analyze Python modules: {e}")
+
+
+def _init_external_refs(modules: dict[str, Any], manifest) -> None:
+    """Collect import edges into `depends_on` packages (PR-4 bridge smoke test)."""
+    from torchtalk.analysis.external_refs import collect_import_refs
+
+    try:
+        refs = collect_import_refs(modules, manifest)
+    except Exception as e:  # never block indexing on the bridge
+        log.warning(f"External ref collection failed: {e}")
+        refs = []
+    _state.external_refs = [r.to_dict() for r in refs]
+    if refs:
+        by_pkg: dict[str, int] = {}
+        for r in refs:
+            by_pkg[r.to_package] = by_pkg.get(r.to_package, 0) + 1
+        log.info(f"External refs: {len(refs)} import edges {by_pkg}")
 
 
 # v3: edges now include import-aware resolution (`linalg.cross(...)` →
@@ -1638,6 +1658,7 @@ def build_index(source: str, wait_for_cpp: bool = True) -> dict:
         "call_graph_building": _state.cpp_building,
         "python_modules": len(_state.py_modules),
         "nn_modules": len(_state.nn_modules),
+        "external_refs": len(_state.external_refs),
         "test_files": len(_state.test_files),
         "test_functions": len(_state.test_functions),
     }

--- a/src/torchtalk/manifests/torch-extension.toml
+++ b/src/torchtalk/manifests/torch-extension.toml
@@ -55,3 +55,16 @@ call_wrappers = [
 
 [python.op_namespaces]
 torch = "aten"
+
+# Resolver lists for cross-package refs (docs/bridge-design.md).
+[bridge]
+cpp_namespaces = [
+    "at",
+    "c10",
+    "torch",
+]
+base_class_namespaces = [
+    "torch.nn",
+    "torch.autograd",
+    "torch.optim",
+]

--- a/tests/test_external_refs.py
+++ b/tests/test_external_refs.py
@@ -1,0 +1,147 @@
+"""Tests for cross-package import refs (analysis/external_refs.py)."""
+
+from __future__ import annotations
+
+import dataclasses
+
+from torchtalk.analysis.external_refs import (
+    REF_KINDS,
+    ExternalRef,
+    bridge_targets,
+    collect_import_refs,
+    refs_by_target,
+)
+from torchtalk.analysis.python_analyzer import PyImport, PyModule
+from torchtalk.harness import ConventionManifest, load_builtin_manifest
+
+
+def _mod(name: str, imports: list[tuple[str, str]], path: str = "") -> PyModule:
+    return PyModule(
+        name=name,
+        file_path=path or f"{name.replace('.', '/')}.py",
+        classes=[],
+        functions=[],
+        imports=[
+            PyImport(
+                module=m, name=n, file_path=path or f"{name}.py", line_number=i + 1
+            )
+            for i, (m, n) in enumerate(imports)
+        ],
+        exports=[],
+    )
+
+
+def _manifest(**overrides) -> ConventionManifest:
+    base = dataclasses.replace(
+        load_builtin_manifest("vllm"),
+        package="vllm",
+        python_package_roots=("vllm",),
+        depends_on=("pytorch",),
+    )
+    return dataclasses.replace(base, **overrides)
+
+
+TARGETS = {"pytorch": ("torch",)}
+
+
+class TestCollectImportRefs:
+    def test_import_and_from_import_become_refs(self):
+        mods = {
+            "vllm.model_executor.layers.linear": _mod(
+                "vllm.model_executor.layers.linear",
+                [
+                    ("torch.nn", "torch.nn"),
+                    ("torch", "nn"),
+                    ("torch.nn.functional", "F"),
+                ],
+            )
+        }
+        refs = collect_import_refs(mods, _manifest(), TARGETS)
+        names = [r.to_name for r in refs]
+        assert names == ["torch.nn", "torch.nn", "torch.nn.functional.F"]
+        assert all(r.kind == "import" for r in refs)
+        assert all(r.to_package == "pytorch" for r in refs)
+        assert all(r.from_symbol == "vllm.model_executor.layers.linear" for r in refs)
+        assert refs[0].evidence.endswith(":1")
+
+    def test_skips_relative_own_package_and_third_party(self):
+        mods = {
+            "vllm.utils": _mod(
+                "vllm.utils",
+                [
+                    ("", "helpers"),
+                    ("vllm.config", "Config"),
+                    ("numpy", "numpy"),
+                    ("torch", "torch"),
+                ],
+            )
+        }
+        refs = collect_import_refs(mods, _manifest(), TARGETS)
+        assert [r.to_name for r in refs] == ["torch"]
+
+    def test_star_import_refers_to_module(self):
+        mods = {"m": _mod("m", [("torch.nn", "*")])}
+        refs = collect_import_refs(mods, _manifest(), TARGETS)
+        assert [r.to_name for r in refs] == ["torch.nn"]
+
+    def test_no_depends_on_yields_nothing(self):
+        mods = {"m": _mod("m", [("torch", "torch")])}
+        assert collect_import_refs(mods, _manifest(depends_on=()), {}) == []
+
+    def test_dedupes_same_target_same_line(self):
+        mod = _mod("m", [("torch", "torch")])
+        mod.imports.append(
+            PyImport(module="torch", name="torch", file_path="m.py", line_number=1)
+        )
+        refs = collect_import_refs({"m": mod}, _manifest(), TARGETS)
+        assert len(refs) == 1
+
+    def test_deterministic_order(self):
+        mods = {
+            "b": _mod("b", [("torch", "torch")]),
+            "a": _mod("a", [("torch.nn", "torch.nn"), ("torch", "torch")]),
+        }
+        refs = collect_import_refs(mods, _manifest(), TARGETS)
+        assert [(r.from_symbol, r.to_name) for r in refs] == [
+            ("a", "torch.nn"),
+            ("a", "torch"),
+            ("b", "torch"),
+        ]
+
+    def test_to_dict_roundtrip(self):
+        ref = ExternalRef("a", "torch", "import", "a.py:1", to_package="pytorch")
+        d = ref.to_dict()
+        assert d == {
+            "from_symbol": "a",
+            "to_name": "torch",
+            "kind": "import",
+            "evidence": "a.py:1",
+            "confidence": 1.0,
+            "to_package": "pytorch",
+        }
+        assert "import" in REF_KINDS and "provides" in REF_KINDS
+
+    def test_refs_by_target_groups(self):
+        refs = [
+            ExternalRef("a", "torch", "import", "a.py:1"),
+            ExternalRef("b", "torch", "import", "b.py:1"),
+            ExternalRef("b", "torch.nn", "import", "b.py:2"),
+        ]
+        grouped = refs_by_target(refs)
+        assert sorted(grouped) == ["torch", "torch.nn"]
+        assert len(grouped["torch"]) == 2
+
+
+class TestBridgeTargets:
+    def test_resolves_depends_on_via_builtin_manifests(self):
+        vllm = load_builtin_manifest("vllm")
+        assert bridge_targets(vllm) == {"pytorch": ("torch",)}
+
+    def test_unknown_dependency_is_skipped(self):
+        assert bridge_targets(_manifest(depends_on=("does-not-exist",))) == {}
+
+    def test_end_to_end_with_builtin_vllm_manifest(self):
+        vllm = load_builtin_manifest("vllm")
+        mods = {"vllm.x": _mod("vllm.x", [("torch", "torch"), ("vllm.y", "z")])}
+        refs = collect_import_refs(mods, vllm)
+        assert [(r.to_name, r.to_package) for r in refs] == [("torch", "pytorch")]

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -122,6 +122,27 @@ class TestTomlManifests:
         assert PYTORCH_MANIFEST.expected_minimums["native_functions"] == 2400
         assert PYTORCH_MANIFEST.depends_on == ()
 
+    def test_bridge_section_inherited_from_torch_extension(self):
+        base = harness_mod.load_builtin_manifest("torch-extension")
+        assert "at" in base.cpp_namespaces and "c10" in base.cpp_namespaces
+        assert "torch.nn" in base.base_class_namespaces
+        assert harness_mod.VLLM_MANIFEST.cpp_namespaces == base.cpp_namespaces
+        assert (
+            harness_mod.VLLM_MANIFEST.base_class_namespaces
+            == base.base_class_namespaces
+        )
+        assert harness_mod.PYTORCH_MANIFEST.cpp_namespaces == ()
+
+    def test_bridge_section_loads_from_toml(self, tmp_path):
+        p = tmp_path / "x.toml"
+        p.write_text(
+            '[package]\nname = "x"\nextends = "torch-extension"\n'
+            '[bridge]\ncpp_namespaces = ["at"]\nbase_class_namespaces = ["torch.nn"]\n'
+        )
+        m = harness_mod.load_manifest(p)
+        assert m.cpp_namespaces == ("at",)
+        assert m.base_class_namespaces == ("torch.nn",)
+
     def test_vllm_extends_torch_extension(self):
         m = harness_mod.VLLM_MANIFEST
         base = harness_mod.load_builtin_manifest("torch-extension")


### PR DESCRIPTION
Introduces ExternalRef(from_symbol, to_name, kind, evidence, confidence) as the single cross-framework edge type, with module-level import edges as the first signal. Adds [bridge] manifest section, ServerState.external_refs + stats + CLI output, and docs/bridge-design.md. 