### PR TITLE
 Add framework onboarding docs and templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-framework.md
+++ b/.github/ISSUE_TEMPLATE/new-framework.md
@@ -1,0 +1,29 @@
+---
+name: Add a framework
+about: Track onboarding a new PyTorch-based framework (manifest, integration anchors, smoke minimums)
+title: "Framework: <name>"
+labels: framework
+---
+
+<!-- Read docs/adding-a-framework.md first. Each box below is one small PR. -->
+
+**Framework:** <name>  ·  **Repo:** <org/repo>  ·  **Pinned ref:** <tag>
+**Why:** <one line — what does indexing this repo let people do?>
+
+### Checklist (one PR each, in order)
+
+- [ ] **Manifest** — `src/torchtalk/manifests/<name>.toml` (`extends = "torch-extension"`, `depends_on = ["pytorch"]`). Verify: `torchtalk index build --source <path> --harness <name>` prints non-zero bindings / python modules.
+- [ ] **Integration anchors** — `tests/integration/<name>.yml` from `_template.yml`; add `<name>` to `matrix.target` in `.github/workflows/integration-tests.yml`. Verify: `<ENV_VAR>=<path> python -m pytest tests/test_binding_detector_pytorch.py -k <name>`.
+- [ ] **Smoke minimums** — `[expected_minimums]` in the manifest; add `<name>` to `.github/workflows/harness-smoke.yml`. Verify: `python scripts/harness_smoke.py --harness <name> --clone`.
+- [ ] **Detector gaps** — anything the counts above surface. File one issue per gap; try a manifest field before touching `analysis/`.
+- [ ] **Docs** — anything `docs/adding-a-framework.md` got wrong or didn't cover. Fix the doc, not just the manifest.
+
+### Baseline counts at the pinned ref
+
+| bindings | cuda_kernels | python_modules | nn_modules | external_refs |
+|---|---|---|---|---|
+| | | | | |
+
+### Known gaps / questions
+
+-

--- a/docs/adding-a-framework.md
+++ b/docs/adding-a-framework.md
@@ -1,0 +1,146 @@
+# Adding a framework
+
+TorchTalk indexes any repo that follows PyTorch's binding and module
+conventions — PyTorch itself, and extensions built on it (vLLM, torchvision,
+…). Onboarding a framework is **data, not code**: you write a TOML manifest, an
+integration-anchor file, and minimums for the smoke test. Each is one small PR
+with a verify command. Open a tracking issue with the "Add a framework" template
+and tick through it.
+
+No detector changes should be needed. If the counts come out wrong, that is a
+bug report against `analysis/` (or a missing manifest field), not something to
+patch around in your manifest.
+
+## 0. Vocabulary
+
+| term | meaning |
+|---|---|
+| **harness** | a registered `ConventionManifest` — the set of conventions for one framework |
+| **manifest** | the TOML file that defines a harness (`src/torchtalk/manifests/<name>.toml`) |
+| **source** | the checkout being indexed (`--source`, or auto-detected) |
+| **snapshot** | the on-disk index for a source at one fingerprint; stores the manifest it was built with |
+| **integration anchors** | `tests/integration/<name>.yml` — concrete facts the detectors must find at a pinned ref |
+| **expected minimums** | per-harness counts the smoke test must reach |
+
+## 1. Manifest (`src/torchtalk/manifests/<name>.toml`)
+
+Start from the abstract base and override only what differs:
+
+```toml
+[package]
+name = "myfw"
+extends = "torch-extension"   # inherits cpp/python/bridge conventions from PyTorch
+depends_on = ["pytorch"]      # bridges are built toward these harnesses
+
+[paths]
+cpp_search_dirs = ["csrc"]    # REQUIRED — where C++/CUDA sources live
+python_search_dirs = ["myfw"] # where Python modules are indexed from
+python_package_roots = ["myfw"]
+
+[cpp]
+# call_wrappers = ["MYFW_BOX"]        # macros that wrap fn pointers in registrations
+
+# [python.op_namespaces]
+# myfw = "myfw"                       # TORCH_LIBRARY(myfw, m) → "myfw::"
+
+[bridge]
+# cpp_namespaces / base_class_namespaces — inherited from torch-extension
+
+[expected_minimums]
+bindings = 100
+python_modules = 200
+```
+
+Rules:
+
+- `extends` — keys in the child **replace** the base value (tuples are not
+  appended). List everything you need.
+- `depends_on` — names of other harnesses. Each import/op/base-class reference
+  from your package into those packages becomes an `ExternalRef` edge
+  (see `docs/bridge-design.md`). Almost always `["pytorch"]`.
+- `[paths] cpp_search_dirs` is the only required key. Everything else has a
+  base-class default.
+- Field reference: `ConventionManifest` in `src/torchtalk/harness.py` — the
+  `_SECTION_FIELDS` table maps TOML sections to dataclass fields.
+
+Verify:
+
+```sh
+torchtalk index build --source /path/to/myfw --harness myfw
+#   Bindings:        …   Python modules:  …   External refs:  …
+```
+
+A repo can also ship its own `.torchtalk.toml` at its root; `torchtalk index
+build/update` auto-activates it. Use that for private forks; upstream the
+manifest into `manifests/` for anything public.
+
+Manifests are loaded with `load_builtin_manifest("myfw")` and registered under
+`[package] name`, so `--harness myfw` works everywhere `--harness pytorch` does.
+
+## 2. Integration anchors (`tests/integration/<name>.yml`)
+
+Copy `tests/integration/_template.yml` (files starting with `_` are skipped by
+the loader). Each anchor is a fact about the pinned `ref` that a detector must
+reproduce — a specific pybind name, a `TORCH_LIBRARY` C++ impl, "this dir has
+CUDA kernels". Grep each one by hand first; pick things that survive patch
+releases.
+
+Keep `sparse_paths` minimal — CI sparse-clones only those directories.
+
+Then add `<name>` to `matrix.target` in
+`.github/workflows/integration-tests.yml`.
+
+Verify:
+
+```sh
+export MYFW_SOURCE=/path/to/myfw       # the env_var you set in the yml
+python -m pytest tests/test_binding_detector_pytorch.py -v -k myfw
+```
+
+## 3. Smoke minimums
+
+`scripts/harness_smoke.py` indexes a real checkout and fails if any count is
+below `[expected_minimums]` in the manifest. Set each minimum to roughly
+90% of the count you measured in step 1 — tight enough to catch a detector
+regression, loose enough to survive upstream churn. Then add `<name>` to
+`.github/workflows/harness-smoke.yml`.
+
+Verify:
+
+```sh
+python scripts/harness_smoke.py --harness myfw --clone
+```
+
+`--harness` only lists harnesses that have `expected_minimums`, so if yours is
+missing from `--help`, step 1 isn't done.
+
+## 4. When the counts look wrong
+
+Common shapes, in the order to try them:
+
+1. **Bindings missing** — a registration macro or wrapper the detector doesn't
+   know. Try `[cpp] call_wrappers` / `[python.op_namespaces]` first.
+2. **Mangled names** (`TORCH_BOX(&foo` instead of `foo`) — same fix as above.
+3. **Python modules missing / doubled qualname** (`myfw.myfw.x`) — check
+   `python_package_roots` matches the directory that holds `__init__.py`.
+4. **0 CUDA kernels** — check `cpp_search_dirs` includes the `.cu` directory.
+5. **0 C++ call-graph edges** — expected without `compile_commands.json`;
+   not a manifest problem.
+
+If a manifest field can't express it, file an issue against `analysis/` with
+the file + line that's mis-detected and the count delta. Don't work around it
+in the manifest.
+
+## 5. Docs are part of the deliverable
+
+If this document was wrong or missing something while you did the steps above,
+fix it in the same PR series. The next framework should be easier than yours.
+
+## Reference: the existing harnesses
+
+| harness | kind | notes |
+|---|---|---|
+| `pytorch` | root | defines the conventions; `depends_on = []` |
+| `torch-extension` | abstract base | not indexable; `extends` target for everything else |
+| `vllm` | extension | first real instance (PR #10); integration anchors + minimums are the open B1/B2 tasks |
+| `torchvision` | extension | manifest only — the intended "do it from the doc" test of this page |

--- a/docs/bridge-design.md
+++ b/docs/bridge-design.md
@@ -34,7 +34,7 @@ signal), not dropped.
 
 | kind          | collected from                                   | resolver list (manifest)      | status |
 |---------------|--------------------------------------------------|-------------------------------|--------|
-| `import`      | module-level `import` / `from ... import`         | `python_package_roots` of dep | PR-4   |
+| `import`      | top-level and nested `import` / `from ... import` statements         | `python_package_roots` of dep | PR-4   |
 | `op`          | `torch.ops.aten.X`, `torch.X` calls               | `[python] op_namespaces`      | C2     |
 | `cpp`         | `at::X`, `c10::X` in C++ sources                  | `[bridge] cpp_namespaces`     | C2     |
 | `base_class`  | `class Foo(torch.nn.Module)`                      | `[bridge] base_class_namespaces` | C2  |
@@ -88,8 +88,9 @@ them via `extends`.
 
 Python analysis is not cached in the JSON index (it runs at load), so
 external refs live in `ServerState.external_refs` as plain dicts and are
-recomputed per load. They are exposed through `get_stats()` as
-`external_refs`. The snapshot schema (v3) is untouched; resolved bridge
+recomputed per load. The count is reported as `external_refs` in the
+stats returned by `build_index` / `update_index` and in `torchtalk index
+build` output. The snapshot schema (v3) is untouched; resolved bridge
 results get their own cache and a v4 schema in C2.
 
 ## Roadmap

--- a/scripts/harness_smoke.py
+++ b/scripts/harness_smoke.py
@@ -115,9 +115,11 @@ def main():
 
     thresholds = get_harness(args.harness).manifest.expected_minimums
     failures = []
-    for key, threshold in thresholds.items():
-        field = key
-        actual = stats.get(field, 0)
+    for field, threshold in thresholds.items():
+        if field not in stats:
+            failures.append(f"{field}: not a stat key (have {sorted(stats)})")
+            continue
+        actual = stats[field]
         print(f"  {field}: {actual} (threshold: >= {threshold})")
         if actual < threshold:
             failures.append(f"{field}: {actual} < {threshold}")

--- a/src/torchtalk/analysis/binding_detector.py
+++ b/src/torchtalk/analysis/binding_detector.py
@@ -102,8 +102,8 @@ _NO_IMPL_MARKERS = ("makeFallthrough", "makeNamedNotSupported")
 _KERNEL_ATTR = (
     r"(?:"
     r"(?:static|inline|__forceinline__)"
-    # call-like macro, e.g. `__launch_bounds__(512, VLLM_BLOCKS_PER_SM(512))`
-    r"|(?:[A-Za-z_]\w*)\s*\((?:[^()]|\([^()]*\))*\)"
+    # call-like macro, e.g. `__attribute__((amdgpu_waves_per_eu(1, 1)))`
+    r"|(?:[A-Za-z_]\w*)\s*\((?:[^()]|\((?:[^()]|\([^()]*\))*\))*\)"
     r"|__[A-Za-z0-9_]+__"
     r")(?:\s|//[^\n]*\n)+"  # separator may include a `//` comment line
 )
@@ -115,13 +115,13 @@ _KERNEL_RETURN_TYPE = (
     r"(?:\s*[*&]+)?"
 )
 _KERNEL_PATTERN = re.compile(
-    r"(?:template\s*<[^>]+>\s*)?"
+    r"(?P<tmpl>template\s*<[^>]+>\s*)?"
     rf"(?:{_KERNEL_ATTR})*"
-    r"__global__\s+"
+    r"(?P<kw>__global__)\s+"
     rf"(?:{_KERNEL_ATTR})*"
     rf"{_KERNEL_RETURN_TYPE}\s+"
     rf"(?:{_KERNEL_ATTR})*"  # e.g. `void __launch_bounds__(256) name(...)`
-    r"(\w+)(?:<([^>]+)>)?\s*\(([^)]*)\)"
+    r"(?P<name>\w+)(?:<(?P<targs>[^>]+)>)?\s*\((?P<args>[^)]*)\)"
 )
 
 # `__device__` helper. CUDA helpers commonly stack `__host__ __device__`
@@ -581,10 +581,13 @@ class BindingDetector:
 
     def _detect_cuda_kernels(self, content: str, file_path: str, graph: BindingGraph):
         for match in _KERNEL_PATTERN.finditer(content):
-            kernel_name = match.group(1)
-            template_params = match.group(2)
-            parameters = match.group(3)
-            line_number = content[: match.start()].count("\n") + 1
+            kernel_name = match.group("name")
+            template_params = match.group("targs")
+            parameters = match.group("args")
+            # Anchor the line on `template` / `__global__`, not on a leading
+            # attribute that the regex may have consumed from the previous line.
+            anchor = match.start("tmpl") if match.group("tmpl") else match.start("kw")
+            line_number = content[:anchor].count("\n") + 1
 
             kernel = CUDAKernel(
                 name=kernel_name,

--- a/src/torchtalk/analysis/external_refs.py
+++ b/src/torchtalk/analysis/external_refs.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from dataclasses import asdict, dataclass
+from pathlib import Path
 from typing import Any
 
 from torchtalk.harness import (
@@ -91,6 +92,7 @@ def collect_import_refs(
     modules: dict[str, Any],
     manifest: ConventionManifest,
     targets: dict[str, tuple[str, ...]] | None = None,
+    source: str | None = None,
 ) -> list[ExternalRef]:
     """Module-level import edges from `modules` into `depends_on` packages.
 
@@ -104,6 +106,7 @@ def collect_import_refs(
     if not targets:
         return []
     own_roots = set(manifest.python_package_roots)
+    root = Path(source).resolve() if source else None
     refs: list[ExternalRef] = []
     for mod_name in sorted(modules):
         mod = modules[mod_name]
@@ -124,12 +127,22 @@ def collect_import_refs(
                     from_symbol=mod_name,
                     to_name=target,
                     kind="import",
-                    evidence=f"{imp.file_path}:{imp.line_number}",
+                    evidence=f"{_rel(imp.file_path, root)}:{imp.line_number}",
                     to_package=pkg,
                 )
             )
     refs.sort(key=lambda r: (r.from_symbol, r.evidence, r.to_name))
     return refs
+
+
+def _rel(path: str, root: Path | None) -> str:
+    """Evidence paths are repo-relative so they survive moving the checkout."""
+    if root is None:
+        return path
+    try:
+        return Path(path).resolve().relative_to(root).as_posix()
+    except ValueError:
+        return path
 
 
 def refs_by_target(refs: Iterable[ExternalRef]) -> dict[str, list[ExternalRef]]:

--- a/src/torchtalk/cli.py
+++ b/src/torchtalk/cli.py
@@ -25,16 +25,33 @@ def _activate_harness(name: str | None) -> bool:
     Returns False (after logging) when the harness is not registered.
     """
     from torchtalk.config import default_harness
-    from torchtalk.harness import set_active_harness
+    from torchtalk.harness import ManifestError, set_active_harness
 
     target = name or default_harness()
     if not target:
         return True
     try:
         set_active_harness(target)
-    except KeyError as e:
+    except (KeyError, ManifestError) as e:
         log.error(str(e))
         return False
+    return True
+
+
+def _prepare_harness(args, source: str | None = None) -> bool:
+    """Activate --harness / configured default, then any repo `.torchtalk.toml`.
+
+    Every command that reads or writes the cache must go through here so the
+    same manifest (and therefore the same package name / search dirs) is used
+    for build, update, serve, status and snapshots.
+    """
+    from torchtalk.config import resolve_source
+
+    if not _activate_harness(args.harness):
+        return False
+    source = resolve_source(cli_flag=source or getattr(args, "source", None))
+    if source:
+        _apply_repo_manifest(source, args.harness)
     return True
 
 
@@ -208,11 +225,11 @@ def cmd_mcp_serve(args):
     from torchtalk.formatting import set_formatter_mode
     from torchtalk.server import run_server
 
-    if not _activate_harness(args.harness):
+    if not _prepare_harness(args):
         return 1
     set_formatter_mode(args.format)
     run_server(
-        pytorch_source=args.source,
+        source=args.source,
         index_path=args.index,
         transport=args.transport,
     )
@@ -221,22 +238,35 @@ def cmd_mcp_serve(args):
 
 def _apply_repo_manifest(source: str, explicit_harness: str | None) -> None:
     """Prefer a `.torchtalk.toml` shipped in the checkout unless --harness was given."""
-    from torchtalk.harness import ManifestError, activate_repo_manifest
+    from torchtalk.harness import (
+        ManifestError,
+        activate_repo_manifest,
+        active_harness_name,
+    )
 
     if explicit_harness:
         return
+    previous = active_harness_name()
     try:
         name = activate_repo_manifest(source)
     except ManifestError as e:
         log.warning("Ignoring repo manifest: %s", e)
         return
-    if name:
+    if name and name != previous:
+        log.warning(
+            "Repo manifest .torchtalk.toml selects harness %r (was %r); "
+            "pass --harness to override",
+            name,
+            previous,
+        )
+    elif name:
         log.info("Using repo-local manifest .torchtalk.toml (harness %r)", name)
 
 
 def cmd_index_build(args):
     """Build or refresh the index for a source checkout and exit."""
     from torchtalk.config import resolve_source
+    from torchtalk.harness import active_harness_name
     from torchtalk.indexer import build_index
 
     if not _activate_harness(args.harness):
@@ -250,6 +280,7 @@ def cmd_index_build(args):
     stats = build_index(source, wait_for_cpp=not args.no_wait)
 
     print(f"Index built for {source}")
+    print(f"  Harness:          {active_harness_name()}")
     print(f"  Bindings:         {stats['bindings']:,}")
     print(f"  CUDA kernels:     {stats['cuda_kernels']:,}")
     print(f"  Native functions: {stats['native_functions']:,}")
@@ -341,7 +372,7 @@ def cmd_snapshot_save(args):
     """Save current cache as a named snapshot."""
     from torchtalk.snapshots import SnapshotError, save_snapshot
 
-    if not _activate_harness(args.harness):
+    if not _prepare_harness(args):
         return 1
     try:
         manifest = save_snapshot(args.name)
@@ -361,7 +392,7 @@ def cmd_snapshot_load(args):
     """Load a named snapshot into the active cache."""
     from torchtalk.snapshots import SnapshotError, find_nearest_snapshot, load_snapshot
 
-    if not _activate_harness(args.harness):
+    if not _prepare_harness(args):
         return 1
     name = args.name
     force = args.force

--- a/src/torchtalk/harness.py
+++ b/src/torchtalk/harness.py
@@ -7,6 +7,7 @@ from different manifests merge via package-qualified symbol IDs (symbols.py).
 
 from __future__ import annotations
 
+import re
 import sys
 from dataclasses import dataclass, field, fields
 from pathlib import Path
@@ -127,6 +128,8 @@ _SECTION_FIELDS: dict[str, dict[str, str]] = {
     },
 }
 _FIELD_TYPES = {f.name: f.type for f in fields(ConventionManifest)}
+_PACKAGE_KEYS = {"name", "extends", "depends_on"}
+_PACKAGE_NAME_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
 
 
 class ManifestError(ValueError):
@@ -137,12 +140,25 @@ def _flatten(data: dict[str, Any], origin: str) -> dict[str, Any]:
     """Map TOML sections onto ConventionManifest field names."""
     out: dict[str, Any] = {}
     pkg = data.get("package", {})
+    if not isinstance(pkg, dict):
+        raise ManifestError(f"{origin}: [package] must be a table")
+    for key in pkg:
+        if key not in _PACKAGE_KEYS:
+            raise ManifestError(f"{origin}: unknown key [package] {key}")
     if "name" in pkg:
-        out["package"] = pkg["name"]
+        name = pkg["name"]
+        if not isinstance(name, str) or not _PACKAGE_NAME_RE.match(name):
+            raise ManifestError(
+                f"{origin}: [package] name must match [A-Za-z0-9_.-]+, got {name!r}"
+            )
+        out["package"] = name
     if "depends_on" in pkg:
         out["depends_on"] = pkg["depends_on"]
     for section, mapping in _SECTION_FIELDS.items():
-        for key, value in data.get(section, {}).items():
+        table = data.get(section, {})
+        if not isinstance(table, dict):
+            raise ManifestError(f"{origin}: [{section}] must be a table")
+        for key, value in table.items():
             if key not in mapping:
                 raise ManifestError(f"{origin}: unknown key [{section}] {key}")
             out[mapping[key]] = value
@@ -155,18 +171,57 @@ def _flatten(data: dict[str, Any], origin: str) -> dict[str, Any]:
     return out
 
 
-def _coerce(name: str, value: Any) -> Any:
-    """Convert TOML values to the field's dataclass type (lists → tuples)."""
-    if name == "registration_calls":
-        return tuple(
-            CallRegistration(
-                r["call"], r["key_arg"], r["target_arg"], r.get("registry", "")
-            )
-            for r in value
-        )
+def _coerce(name: str, value: Any, origin: str = "<dict>") -> Any:
+    """Convert TOML values to the field's dataclass type (lists → tuples).
+
+    Raises ManifestError when the TOML value has the wrong shape, so a typo
+    like `cpp_search_dirs = "csrc"` fails at load time rather than iterating
+    over characters deep inside the indexer.
+    """
     ftype = str(_FIELD_TYPES[name])
-    if ftype.startswith("tuple") and isinstance(value, list):
+    if name == "registration_calls":
+        if not isinstance(value, list) or not all(isinstance(r, dict) for r in value):
+            raise ManifestError(
+                f"{origin}: registration_calls must be a list of tables"
+            )
+        out = []
+        for r in value:
+            missing = [k for k in ("call", "key_arg", "target_arg") if k not in r]
+            if missing:
+                raise ManifestError(
+                    f"{origin}: registration_calls entry missing {missing}: {r}"
+                )
+            out.append(
+                CallRegistration(
+                    r["call"], r["key_arg"], r["target_arg"], r.get("registry", "")
+                )
+            )
+        return tuple(out)
+    if name == "expected_minimums":
+        if not isinstance(value, dict) or not all(
+            isinstance(v, int) and not isinstance(v, bool) for v in value.values()
+        ):
+            raise ManifestError(
+                f"{origin}: [expected_minimums] values must be integers"
+            )
+        return dict(value)
+    if ftype.startswith("tuple"):
+        if not isinstance(value, list) or not all(isinstance(v, str) for v in value):
+            raise ManifestError(f"{origin}: {name} must be a list of strings")
         return tuple(value)
+    if ftype == "str":
+        if not isinstance(value, str):
+            raise ManifestError(f"{origin}: {name} must be a string")
+        return value
+    if ftype.startswith("dict"):
+        if not isinstance(value, dict) or not all(
+            isinstance(v, (str, int)) and not isinstance(v, bool)
+            for v in value.values()
+        ):
+            raise ManifestError(
+                f"{origin}: {name} must be a table of strings or integers"
+            )
+        return dict(value)
     return value
 
 
@@ -186,7 +241,7 @@ def manifest_from_dict(
     if base is not None:
         values.update({f.name: getattr(base, f.name) for f in fields(base)})
     for name, raw in _flatten(data, origin).items():
-        values[name] = _coerce(name, raw)
+        values[name] = _coerce(name, raw, origin)
     if "package" not in values:
         raise ManifestError(f"{origin}: [package] name is required")
     if "cpp_search_dirs" not in values:
@@ -196,7 +251,10 @@ def manifest_from_dict(
 
 def _read_toml(path: Path) -> dict[str, Any]:
     with open(path, "rb") as f:
-        return tomllib.load(f)
+        try:
+            return tomllib.load(f)
+        except tomllib.TOMLDecodeError as e:
+            raise ManifestError(f"{path}: {e}") from e
 
 
 def load_manifest(path: str | Path, _seen: tuple[str, ...] = ()) -> ConventionManifest:
@@ -218,7 +276,10 @@ def load_manifest(path: str | Path, _seen: tuple[str, ...] = ()) -> ConventionMa
         builtin = MANIFESTS_DIR / f"{parent}.toml"
         candidate = builtin if builtin.exists() else path.parent / parent
         if not candidate.exists():
-            raise ManifestError(f"{origin}: extends {parent!r} not found")
+            raise ManifestError(
+                f"{origin}: extends {parent!r} not found "
+                f"(built-ins: {builtin_manifest_names()})"
+            )
         base = load_manifest(candidate, (*_seen, origin))
     return manifest_from_dict(data, base=base, origin=origin)
 
@@ -269,19 +330,36 @@ def list_harnesses() -> list[str]:
     return sorted(_REGISTRY)
 
 
+def _ensure_registered(name: str) -> None:
+    """Lazily register a shipped `manifests/<name>.toml` on first use.
+
+    Lets `--harness myfw` work for a profile that exists only as a TOML file
+    (e.g. one dropped into `manifests/` by a contributor) without touching
+    the hardcoded registrations below. Raises KeyError when no such profile
+    exists; a malformed profile raises ManifestError.
+    """
+    if name in _REGISTRY:
+        return
+    path = MANIFESTS_DIR / f"{name}.toml"
+    if not path.is_file():
+        raise KeyError(
+            f"Unknown harness {name!r}. Registered: {sorted(_REGISTRY)}; "
+            f"built-in manifests: {builtin_manifest_names()}"
+        )
+    register_harness(name, ManifestHarness(load_manifest(path)))
+
+
 def get_harness(name: str | None = None) -> Harness:
     """Return the named harness, or the active one when no name is given."""
     key = name or _ACTIVE
-    if key not in _REGISTRY:
-        raise KeyError(f"Unknown harness {key!r}. Registered: {sorted(_REGISTRY)}")
+    _ensure_registered(key)
     return _REGISTRY[key]
 
 
 def set_active_harness(name: str) -> None:
     """Select the harness used when get_harness() is called without a name."""
     global _ACTIVE
-    if name not in _REGISTRY:
-        raise KeyError(f"Unknown harness {name!r}. Registered: {sorted(_REGISTRY)}")
+    _ensure_registered(name)
     _ACTIVE = name
 
 

--- a/src/torchtalk/indexer.py
+++ b/src/torchtalk/indexer.py
@@ -73,7 +73,7 @@ class ServerState:
     kernel_impl_to_op: dict[str, str] = field(default_factory=dict)
     dispatch_to_op: dict[str, str] = field(default_factory=dict)
 
-    pytorch_source: str | None = None
+    source: str | None = None
     package: PackageIdentity | None = None
     cpp_extractor: Any = None
     cpp_building: bool = False
@@ -284,9 +284,7 @@ def _impls_from_extractor(target: str) -> list[dict]:
     extractor = _state.cpp_extractor
     if not extractor:
         return []
-    src_prefix = (
-        (_state.pytorch_source.rstrip("/") + "/") if _state.pytorch_source else None
-    )
+    src_prefix = (_state.source.rstrip("/") + "/") if _state.source else None
     out: list[dict] = []
     for qname, (file, line) in extractor.function_locations.items():
         if qname.rsplit("::", 1)[-1] != target:
@@ -596,8 +594,8 @@ def _cpp_status() -> str:
         return "C++ call graph building in background (~1-2 min). Try again shortly."
 
     if not _state.cpp_extractor:
-        if _state.pytorch_source:
-            src = Path(_state.pytorch_source)
+        if _state.source:
+            src = Path(_state.source)
             if (
                 not (src / "compile_commands.json").exists()
                 and not (src / "build/compile_commands.json").exists()
@@ -606,7 +604,7 @@ def _cpp_status() -> str:
                     "C++ call graph unavailable - "
                     "`compile_commands.json` not found.\n\n"
                     "**To enable:** Build PyTorch once:\n"
-                    f"```\ncd {_state.pytorch_source}\npython setup.py develop\n```"
+                    f"```\ncd {_state.source}\npython setup.py develop\n```"
                 )
         return "C++ call graph unavailable. Install libclang or build PyTorch."
 
@@ -627,12 +625,13 @@ def _ensure_loaded(component: str = "bindings"):
     }
     loaded, msg = checks.get(component, (True, ""))
     if not loaded:
-        raise RuntimeError(f"{msg}. Start server with --pytorch-source.")
+        raise RuntimeError(f"{msg}. Start server with --source.")
 
 
 def _init_python_modules(source: str):
     """Initialize Python module analysis using configured search directories."""
     global _state
+    _state.external_refs = []
 
     try:
         from .analysis.alias_map import build_function_alias_map
@@ -673,17 +672,17 @@ def _init_python_modules(source: str):
                 f"{len(_state.nn_modules)} nn.Module classes"
             )
             _init_py_cpp_edges(source)
-            _init_external_refs(all_modules, manifest)
+            _init_external_refs(all_modules, manifest, source)
     except Exception as e:
         log.warning(f"Failed to analyze Python modules: {e}")
 
 
-def _init_external_refs(modules: dict[str, Any], manifest) -> None:
+def _init_external_refs(modules: dict[str, Any], manifest, source: str) -> None:
     """Collect import edges into `depends_on` packages (PR-4 bridge smoke test)."""
     from torchtalk.analysis.external_refs import collect_import_refs
 
     try:
-        refs = collect_import_refs(modules, manifest)
+        refs = collect_import_refs(modules, manifest, source=source)
     except Exception as e:  # never block indexing on the bridge
         log.warning(f"External ref collection failed: {e}")
         refs = []
@@ -728,7 +727,7 @@ def _save_py_cpp_edges_cache(path: Path) -> None:
     """Persist the py→cpp edge index to JSON, versioned and fingerprinted."""
     payload = {
         "version": _PY_CPP_EDGES_CACHE_VERSION,
-        "fingerprint": _source_fingerprint(_state.pytorch_source or ""),
+        "fingerprint": _source_fingerprint(_state.source or ""),
         "edges": _state.py_to_cpp_edges,
     }
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -786,7 +785,7 @@ def _init_from_source(source: str):
         _state.registrations = data.get("registrations", {})
         _build_indexes(_state)
 
-    _state.pytorch_source = str(src)
+    _state.source = str(src)
     _state.package = detect_package_identity(str(src), active_manifest().package)
     _init_decomp_aliases(str(src))
     _init_backward_bridge()
@@ -849,7 +848,7 @@ def _save_test_infra_cache(path: Path) -> None:
     """Persist test infrastructure state to JSON. Sets become sorted lists."""
     payload = {
         "version": _TEST_INFRA_CACHE_VERSION,
-        "fingerprint": _source_fingerprint(_state.pytorch_source or ""),
+        "fingerprint": _source_fingerprint(_state.source or ""),
         "test_files": _state.test_files,
         "test_classes": _state.test_classes,
         "test_functions": _state.test_functions,
@@ -1245,9 +1244,9 @@ def _parse_opinfo_registry(opinfo_path: str):
         except SyntaxError:
             return
 
-        if _state.pytorch_source:
+        if _state.source:
             try:
-                rel_path = str(path.relative_to(_state.pytorch_source))
+                rel_path = str(path.relative_to(_state.source))
             except ValueError:
                 rel_path = str(path)
         else:
@@ -1617,6 +1616,7 @@ def _update_call_graph(
         return {"skipped": str(e)}
 
     stats["header_affected_tus"] = len(header_affected)
+    stats.setdefault("external_refs", len(_state.external_refs))
     stats["uncovered_headers"] = len(uncovered)
     stats["uncovered_sample"] = sorted(uncovered)[:5]
     stats["on_uncovered"] = on_uncovered

--- a/src/torchtalk/manifests/pytorch.toml
+++ b/src/torchtalk/manifests/pytorch.toml
@@ -76,13 +76,13 @@ native_functions_yaml = "aten/src/ATen/native/native_functions.yaml"
 derivatives_yaml = "tools/autograd/derivatives.yaml"
 decomp_alias_paths = [
     "torch/_decomp/decompositions.py",
+    "torch/_decomp/decompositions_for_jvp.py",
     "torch/_refs/__init__.py",
-    "torch/_refs/nn/functional/__init__.py",
-    "torch/_refs/linalg/__init__.py",
-    "torch/_refs/special/__init__.py",
+    "torch/_refs/_conversions.py",
     "torch/_refs/fft.py",
-    "torch/_prims/__init__.py",
-    "torch/_decomp/decompositions_for_rng.py",
+    "torch/_refs/linalg/__init__.py",
+    "torch/_refs/nn/functional/__init__.py",
+    "torch/_refs/special/__init__.py",
 ]
 dispatch_stub_root = "aten/src/ATen/native"
 
@@ -99,10 +99,10 @@ registration_macros = [
     "RegisterOperators",
 ]
 call_wrappers = [
+    "TORCH_FN_BOXED",
+    "TORCH_FN",
     "TORCH_BOX",
     "TORCH_SELECTIVE_FN",
-    "TORCH_FN",
-    "TORCH_SELECTIVE_SCHEMA",
 ]
 
 [python.decorator_registries]

--- a/src/torchtalk/manifests/torch-extension.toml
+++ b/src/torchtalk/manifests/torch-extension.toml
@@ -47,10 +47,10 @@ registration_macros = [
     "RegisterOperators",
 ]
 call_wrappers = [
+    "TORCH_FN_BOXED",
+    "TORCH_FN",
     "TORCH_BOX",
     "TORCH_SELECTIVE_FN",
-    "TORCH_FN",
-    "TORCH_SELECTIVE_SCHEMA",
 ]
 
 [python.op_namespaces]

--- a/src/torchtalk/server.py
+++ b/src/torchtalk/server.py
@@ -37,8 +37,8 @@ async def get_status() -> str:
     md = create_formatter()
     md.h2("TorchTalk Status")
 
-    if _state.pytorch_source:
-        md.code("PyTorch Source", _state.pytorch_source)
+    if _state.source:
+        md.code("PyTorch Source", _state.source)
     else:
         md.bold("PyTorch Source", "Not configured")
     md.blank()
@@ -83,8 +83,8 @@ async def get_status() -> str:
         md.item(f"Call edges: {stats['total_call_edges']:,}", 1)
     else:
         md.bold("Status", "Not available")
-        if _state.pytorch_source:
-            src = Path(_state.pytorch_source)
+        if _state.source:
+            src = Path(_state.source)
             # PyTorch's `python setup.py develop` lands compile_commands.json
             # in `build/`; some checkouts have it at the root. Check both,
             # matching cli.py / indexer.py / cpp_call_graph.py.
@@ -302,7 +302,7 @@ async def affected(funcs: str, depth: int = 3) -> str:
 
 
 def run_server(
-    pytorch_source: str | None = None,
+    source: str | None = None,
     index_path: str | None = None,
     transport: str = "stdio",
 ):
@@ -311,7 +311,7 @@ def run_server(
     error via `_ensure_loaded` until the data is ready."""
     import threading
 
-    source = pytorch_source or _auto_detect_source()
+    source = source or _auto_detect_source()
 
     def _bg_init():
         try:

--- a/src/torchtalk/tools/common.py
+++ b/src/torchtalk/tools/common.py
@@ -7,7 +7,7 @@ from ..indexer import _state
 
 
 def _rel_path(path: str) -> str:
-    return relative_path(path, _state.pytorch_source)
+    return relative_path(path, _state.source)
 
 
 def _with_note(text: str) -> str:

--- a/src/torchtalk/tools/tests.py
+++ b/src/torchtalk/tools/tests.py
@@ -177,8 +177,8 @@ async def _do_list_test_utils() -> str:
     for path, info in utility_info.items():
         if path in _state.test_utilities:
             exists = True
-        elif _state.pytorch_source:
-            exists = (Path(_state.pytorch_source) / path).exists()
+        elif _state.source:
+            exists = (Path(_state.source) / path).exists()
         else:
             exists = False
         status = "[ok]" if exists else "[missing]"

--- a/tests/integration/_template.yml
+++ b/tests/integration/_template.yml
@@ -1,0 +1,51 @@
+# Template for a new integration target. Copy to tests/integration/<name>.yml
+# (files starting with "_" are ignored by the loader) and fill in every value.
+#
+# The file drives two things:
+#   1. tests/test_binding_detector_pytorch.py — each `anchors` entry becomes a
+#      parametrized test that runs when $env_var points at a checkout.
+#   2. .github/workflows/integration-tests.yml — add <name> to `matrix.target`
+#      so CI does a sparse clone of `repo`@`ref` restricted to `sparse_paths`.
+#
+# Verify locally:
+#   export <ENV_VAR>=/path/to/checkout
+#   python -m pytest tests/test_binding_detector_pytorch.py -v -k <name>
+
+repo: org/repo            # GitHub "owner/name" used for the CI sparse clone
+ref: v0.0.0               # tag or SHA — pin it; anchors are version-specific
+env_var: FRAMEWORK_SOURCE # env var that points at a local checkout
+
+# Directories CI needs. Keep this minimal — the whole repo is NOT cloned.
+sparse_paths:
+  - csrc
+  - pkg/nn
+
+# Anchors: concrete facts about the pinned ref that the detectors must find.
+# Pick things that are stable across patch releases and cheap to verify by
+# hand (grep them first). Supported checks:
+#
+#   pybind_name             `file` defines a pybind11 function named `value`
+#   torch_library_cpp_name  `file` registers a TORCH_LIBRARY op whose C++
+#                           implementation is named `value`
+#   has_cuda_kernel         at least one file under `dir` matching `glob`
+#                           (and containing `content_filter`) yields a kernel
+#   has_at_dispatch         at least one file under `dir` uses AT_DISPATCH_*
+#   has_binding_types       bindings under `dir` cover every type in `value`
+#                           (e.g. [pybind11, torch_library])
+anchors:
+  - file: csrc/bindings.cpp
+    check: pybind_name
+    value: some_exported_function
+
+  - file: csrc/ops.cpp
+    check: torch_library_cpp_name
+    value: some_cpp_impl
+
+  - dir: csrc
+    check: has_cuda_kernel
+    glob: "*.cu"
+    content_filter: __global__
+
+  - dir: csrc
+    check: has_binding_types
+    value: [pybind11, torch_library]

--- a/tests/test_affected_tool.py
+++ b/tests/test_affected_tool.py
@@ -50,7 +50,7 @@ def affected_state(mock_state):
     s.opinfo_alias_map = {}
     s.opinfo_test_files = set()
     s.test_attr_index = {}
-    s.pytorch_source = "/fake"
+    s.source = "/fake"
     indexer._build_indexes(s)
     return s
 

--- a/tests/test_binding_detector.py
+++ b/tests/test_binding_detector.py
@@ -133,7 +133,7 @@ class TestImplRegex:
 class TestKernelPattern:
     def _name(self, code: str) -> str | None:
         m = _KERNEL_PATTERN.search(code)
-        return m.group(1) if m else None
+        return m.group("name") if m else None
 
     def test_simple_global_kernel(self):
         assert self._name("__global__ void simpleKernel(int* a) {") == "simpleKernel"
@@ -206,10 +206,35 @@ class TestKernelPattern:
         )
         assert self._name(code) == "hadamard_transform_kernel"
 
-    def test_launch_bounds_is_never_a_kernel_name(self):
-        code = "__global__ void __launch_bounds__(512) real_name(int* a) {"
-        names = [m.group(1) for m in _KERNEL_PATTERN.finditer(code)]
-        assert names == ["real_name"]
+    def test_double_paren_attribute(self):
+        code = (
+            "template <typename scalar_t, int THRDS>\n"
+            "__global__ void __launch_bounds__(WvPrGrp * THRDS)\n"
+            "__attribute__((amdgpu_waves_per_eu(1, 1)))\n"
+            "wvSplitK_hf_sml_(const int K, const scalar_t* B) {"
+        )
+        assert self._name(code) == "wvSplitK_hf_sml_"
+
+    def test_line_number_anchors_on_global_keyword(self):
+        # Attributes preceding `__global__` on earlier lines must not shift the
+        # reported line; the kernel starts where `template`/`__global__` is.
+        code = (
+            "int x;\n"
+            "\n"
+            "static __global__ void __launch_bounds__(256)\n"
+            "line_kernel(int* a) {}\n"
+            "\n"
+            "template <typename T>\n"
+            "__global__ void other_kernel(T* a) {}\n"
+        )
+        lines = {
+            m.group("name"): code[
+                : m.start("tmpl") if m.group("tmpl") else m.start("kw")
+            ].count("\n")
+            + 1
+            for m in _KERNEL_PATTERN.finditer(code)
+        }
+        assert lines == {"line_kernel": 3, "other_kernel": 6}
 
 
 class TestDevicePattern:

--- a/tests/test_binding_detector_pytorch.py
+++ b/tests/test_binding_detector_pytorch.py
@@ -30,6 +30,8 @@ def _load_manifests() -> list[dict]:
     manifests = []
     if MANIFESTS_DIR.exists():
         for path in sorted(MANIFESTS_DIR.glob("*.yml")):
+            if path.name.startswith("_"):
+                continue  # _template.yml and other non-target files
             with open(path) as f:
                 manifest = yaml.safe_load(f)
                 manifest["_name"] = path.stem

--- a/tests/test_external_refs.py
+++ b/tests/test_external_refs.py
@@ -52,13 +52,13 @@ class TestCollectImportRefs:
                 [
                     ("torch.nn", "torch.nn"),
                     ("torch", "nn"),
-                    ("torch.nn.functional", "F"),
+                    ("torch.nn.functional", "torch.nn.functional"),
                 ],
             )
         }
         refs = collect_import_refs(mods, _manifest(), TARGETS)
         names = [r.to_name for r in refs]
-        assert names == ["torch.nn", "torch.nn", "torch.nn.functional.F"]
+        assert names == ["torch.nn", "torch.nn", "torch.nn.functional"]
         assert all(r.kind == "import" for r in refs)
         assert all(r.to_package == "pytorch" for r in refs)
         assert all(r.from_symbol == "vllm.model_executor.layers.linear" for r in refs)

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -67,14 +67,14 @@ class _FakeExtractor:
 @pytest.fixture
 def reset_extractor():
     prior = indexer._state.cpp_extractor
-    prior_src = indexer._state.pytorch_source
-    indexer._state.pytorch_source = "/fake/source"
+    prior_src = indexer._state.source
+    indexer._state.source = "/fake/source"
     indexer._state.bindings = [{"python_name": "fake"}]  # satisfies _ensure_loaded
     try:
         yield
     finally:
         indexer._state.cpp_extractor = prior
-        indexer._state.pytorch_source = prior_src
+        indexer._state.source = prior_src
         indexer._state.bindings = []
 
 

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -117,6 +117,12 @@ class TestTomlManifests:
         assert m.test_utility_modules == tuple(P.TEST_UTILITY_MODULES)
         assert m.exclude_patterns == tuple(P.EXCLUDE_PATTERNS)
         assert m.registration_macros == tuple(P.CPP_BINDING_PATTERNS)
+        # Drift guards: the TOML must mirror the detector constants it replaces.
+        from torchtalk.analysis.binding_detector import _IMPL_WRAPPERS
+        from torchtalk.analysis.decomp_aliases import _DECOMP_FILES
+
+        assert m.cpp_call_wrappers == tuple(_IMPL_WRAPPERS)
+        assert m.decomp_alias_paths == tuple(_DECOMP_FILES)
 
     def test_pytorch_expected_minimums(self):
         assert PYTORCH_MANIFEST.expected_minimums["native_functions"] == 2400
@@ -197,6 +203,41 @@ class TestTomlManifests:
             harness_mod.load_manifest(bad)
         with pytest.raises(harness_mod.ManifestError, match="not found"):
             harness_mod.load_manifest(tmp_path / "nope.toml")
+
+    def test_value_type_validation(self, tmp_path):
+        cases = {
+            '[paths]\ncpp_search_dirs = "csrc"': "list of strings",
+            "[expected_minimums]\nbindings = true": "must be integers",
+            '[[cpp.registration_calls]]\ncall = "x"': "registration_calls",
+            "[python.op_namespaces]\nx = true": "table of strings",
+        }
+        for body, msg in cases.items():
+            p = tmp_path / "v.toml"
+            head = '[package]\nname = "v"\n'
+            if not body.startswith("[paths]"):
+                head += '[paths]\ncpp_search_dirs = ["csrc"]\n'
+            p.write_text(f"{head}{body}\n")
+            with pytest.raises(harness_mod.ManifestError, match=msg):
+                harness_mod.load_manifest(p)
+
+    def test_toml_syntax_error_is_manifest_error(self, tmp_path):
+        p = tmp_path / "broken.toml"
+        p.write_text("[package\nname = ")
+        with pytest.raises(harness_mod.ManifestError, match=r"broken\.toml"):
+            harness_mod.load_manifest(p)
+
+    def test_unknown_package_key_and_bad_name(self, tmp_path):
+        p = tmp_path / "k.toml"
+        p.write_text('[package]\nname = "k"\nversion = "1"\n')
+        with pytest.raises(harness_mod.ManifestError, match=r"\[package\] version"):
+            harness_mod.load_manifest(p)
+        p.write_text('[package]\nname = "bad name"\n')
+        with pytest.raises(harness_mod.ManifestError, match="name"):
+            harness_mod.load_manifest(p)
+
+    def test_unknown_harness_error_lists_builtins(self):
+        with pytest.raises(KeyError, match="built-in manifests"):
+            harness_mod.get_harness("definitely-not-a-harness")
 
     def test_repo_local_manifest_activates(self, tmp_path):
         prev = harness_mod.active_harness_name()

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -141,13 +141,13 @@ class TestImplsFromExtractor:
     @pytest.fixture(autouse=True)
     def reset_state(self):
         prior = indexer._state.cpp_extractor
-        prior_src = indexer._state.pytorch_source
-        indexer._state.pytorch_source = None
+        prior_src = indexer._state.source
+        indexer._state.source = None
         try:
             yield
         finally:
             indexer._state.cpp_extractor = prior
-            indexer._state.pytorch_source = prior_src
+            indexer._state.source = prior_src
 
     def _fake_extractor(self, locations: dict) -> SimpleNamespace:
         return SimpleNamespace(function_locations=locations)
@@ -192,7 +192,7 @@ class TestImplsFromExtractor:
         assert _impls_from_extractor("nope") == []
 
     def test_out_of_tree_matches_filtered(self):
-        indexer._state.pytorch_source = "/src/pytorch"
+        indexer._state.source = "/src/pytorch"
         indexer._state.cpp_extractor = self._fake_extractor(
             {
                 "at::native::t": ("/src/pytorch/aten/T.cpp", 10),
@@ -280,18 +280,18 @@ class TestPyCppEdgesCache:
     @pytest.fixture(autouse=True)
     def reset_state(self):
         prior_edges = indexer._state.py_to_cpp_edges
-        prior_src = indexer._state.pytorch_source
+        prior_src = indexer._state.source
         try:
             yield
         finally:
             indexer._state.py_to_cpp_edges = prior_edges
-            indexer._state.pytorch_source = prior_src
+            indexer._state.source = prior_src
 
     def test_save_and_load_round_trip(self, tmp_path, monkeypatch):
         monkeypatch.setattr(
             indexer, "_source_fingerprint", lambda _: "deadbeefdeadbeef"
         )
-        indexer._state.pytorch_source = "/fake/source"
+        indexer._state.source = "/fake/source"
         indexer._state.py_to_cpp_edges = {
             "aten::add": [{"caller_qualname": "torch.x.f", "file": "/x.py", "line": 5}]
         }
@@ -304,7 +304,7 @@ class TestPyCppEdgesCache:
 
     def test_load_rejects_stale_fingerprint(self, tmp_path, monkeypatch):
         monkeypatch.setattr(indexer, "_source_fingerprint", lambda _: "fp_v1")
-        indexer._state.pytorch_source = "/fake/source"
+        indexer._state.source = "/fake/source"
         indexer._state.py_to_cpp_edges = {"aten::add": []}
         cache = tmp_path / "edges.json"
         _save_py_cpp_edges_cache(cache)
@@ -669,7 +669,7 @@ class TestParseOpInfoRegistry:
 
         _state.opinfo_registry = {}
         _state.opinfo_alias_map = {}
-        _state.pytorch_source = str(tmp_path)
+        _state.source = str(tmp_path)
 
         opinfo_file = tmp_path / "opinfos.py"
         opinfo_file.write_text(

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -17,7 +17,7 @@ def state_without_call_graph():
         s.bindings,
         s.cuda_kernels,
         s.cpp_extractor,
-        s.pytorch_source,
+        s.source,
     )
     s.native_functions = {
         "add": {
@@ -37,7 +37,7 @@ def state_without_call_graph():
         {"name": "add_kernel", "file_path": "/src/a.cu", "line_number": 3}
     ]
     s.cpp_extractor = None
-    s.pytorch_source = "/src"
+    s.source = "/src"
     indexer._build_indexes(s)
     try:
         yield s
@@ -47,7 +47,7 @@ def state_without_call_graph():
             s.bindings,
             s.cuda_kernels,
             s.cpp_extractor,
-            s.pytorch_source,
+            s.source,
         ) = saved
         indexer._build_indexes(s)
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -14,7 +14,7 @@ def server_state(mock_state):
     s = mock_state
     s.bindings = [{"python_name": "add", "dispatch_key": "CPU"}]
     s.native_functions = {"add": {"base_name": "add"}}
-    s.pytorch_source = "/fake/pytorch"
+    s.source = "/fake/pytorch"
     s.cpp_extractor = None
     s.cpp_building = False
     s.py_modules = {}
@@ -31,7 +31,7 @@ def server_state(mock_state):
 
 
 class TestGetStatus:
-    def test_shows_pytorch_source(self, server_state):
+    def test_shows_source(self, server_state):
         out = asyncio.run(get_status())
         assert "/fake/pytorch" in out
 
@@ -61,7 +61,7 @@ class TestGetStatus:
         assert "Functions: 51,000" in out
 
     def test_cpp_unavailable_no_source(self, server_state):
-        server_state.pytorch_source = None
+        server_state.source = None
         out = asyncio.run(get_status())
         assert "Not available" in out
 
@@ -101,6 +101,6 @@ class TestRunServer:
         monkeypatch.setattr("torchtalk.server.mcp.run", lambda **kw: None)
         monkeypatch.setattr("threading.Thread", FakeThread)
 
-        run_server(pytorch_source="/fake", transport="stdio")
+        run_server(source="/fake", transport="stdio")
 
         assert captured["daemon"] is True

--- a/tests/test_tests_tool.py
+++ b/tests/test_tests_tool.py
@@ -118,7 +118,7 @@ def test_tool_state(mock_state):
             "exists": True,
         },
     }
-    s.pytorch_source = None
+    s.source = None
     indexer._build_indexes(s)
     return s
 


### PR DESCRIPTION
- Adds docs/adding-a-framework.md, a new-framework issue template with per-PR checklist, and tests/integration/_template.yml. 
- Renames ServerState.pytorch_source → source (persisted snapshot/config keys deliberately kept until schema v4). 
- Folds in review-pass hardening: manifest value-type validation, TOMLDecodeError → ManifestError, lazy built-in registration, TOML↔constant drift guards. 